### PR TITLE
Update CopyTfsBinaries to only copy if missing or newer

### DIFF
--- a/Qwiq/Qwiq.Core/build/microsoft.ie.qwiq.core.targets
+++ b/Qwiq/Qwiq.Core/build/microsoft.ie.qwiq.core.targets
@@ -10,7 +10,9 @@
     </PrepareForRunDependsOn>
   </PropertyGroup>
   <Target Name="CopyTfsBinaries" DependsOnTargets="CopyFilesToOutputDirectory">
-    <Copy SourceFiles="@(TfsBinaries)" DestinationFiles="@(TfsBinaries->'$(OutDir)\%(Filename)%(Extension)')">
+    <Copy SourceFiles="@(TfsBinaries)"
+            DestinationFiles="@(TfsBinaries->'$(OutDir)\%(Filename)%(Extension)')"
+            Condition="!Exists('$(OutDir)\%(Filename)%(Extension)') OR $([System.DateTime]::Parse('%(ModifiedTime)').Ticks) &gt; $([System.IO.File]::GetLastWriteTime('$(OutDir)\%(Filename)%(Extension)').Ticks)">
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
   </Target>


### PR DESCRIPTION
The CopyTfsBinaries target executed during the CopyFilesToOutputDirectory target. If the web server was up, the copy would fail because the DLL would be in use.

The copy command updated to only copy if the DLLs are missing (e.g. first time or clean build), or the DLLs are newer than the ones in the bin folder (by filesystem modify timestamp).
