### PR TITLE
Use improved auth authority uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ using Microsoft.IE.Qwiq.Credentials;
 var creds = CredentialsFactory
                 .GetInstance()
                 .CreateAadCredentials(
-                	"499b84ac-1321-427f-aa17-267ca6975798", // Visual Studio Resource String
-                	"872cd9fa-d31f-45e0-9eab-6e460a02d1f1", // TFS Client Id
-                	"https://login.windows.net/common/");   // Identity Authority
+                    "499b84ac-1321-427f-aa17-267ca6975798", // Visual Studio Resource String
+                    "872cd9fa-d31f-45e0-9eab-6e460a02d1f1", // TFS Client Id
+                    "https://login.microsoftonline.com");   // Identity Authority
 
 var uri = new Uri("https://microsoft.visualstudio.com/DefaultCollection");
 
@@ -59,9 +59,9 @@ $credsFactory = [Microsoft.IE.Qwiq.Credentials.CredentialsFactory]::GetInstance(
 
 # VS Resource String, TfsClientId, and Authority
 $creds = $credsFactory.CreateAadCredentials(
-			"499b84ac-1321-427f-aa17-267ca6975798", 
-			"872cd9fa-d31f-45e0-9eab-6e460a02d1f1", 
-			"https://login.windows.net/common/")
+            "499b84ac-1321-427f-aa17-267ca6975798",
+            "872cd9fa-d31f-45e0-9eab-6e460a02d1f1",
+            "https://login.microsoftonline.com")
 
 $uri = [Uri]"https://microsoft.visualstudio.com/DefaultCollection"
 


### PR DESCRIPTION
- Azure AD now supports login.microsoftonline.com in addition to
  login.windows.net as auth authorities
- login.microsoftonline.com uses fewer redirects and has improved
  reliability (see
  http://blogs.technet.com/b/ad/archive/2015/03/06/simplifying-our-azure-ad-authentication-flows.aspx)
- Update our README to use the new recommended uri
