### PR TITLE
Expose MembershipQuery enum on IdentityManagmentService2::ReadIdentities

### DIFF
--- a/Qwiq/Qwiq.Core.Tests/IdentityManagementServiceProxyTests.cs
+++ b/Qwiq/Qwiq.Core.Tests/IdentityManagementServiceProxyTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.IE.Qwiq.Core.Tests
     {
         public override void When()
         {
-            Actual = Service.ReadIdentities(IdentitySearchFactor.AccountName, new[] {"I Do Not Exist"});
+            Actual = Service.ReadIdentities(IdentitySearchFactor.AccountName, new[] {"I Do Not Exist"}, MembershipQuery.None);
         }
 
         [TestMethod]
@@ -43,7 +43,7 @@ namespace Microsoft.IE.Qwiq.Core.Tests
     {
         public override void When()
         {
-            Actual = Service.ReadIdentities(new [] { new MockIdentityDescriptor() });
+            Actual = Service.ReadIdentities(new [] { new MockIdentityDescriptor() }, MembershipQuery.None);
         }
 
         [TestMethod]

--- a/Qwiq/Qwiq.Core.Tests/Mocks/MockIdentityManagementService2.cs
+++ b/Qwiq/Qwiq.Core.Tests/Mocks/MockIdentityManagementService2.cs
@@ -15,43 +15,31 @@ namespace Microsoft.IE.Qwiq.Core.Tests.Mocks
             };
         }
 
-        public TeamFoundationIdentity[] ReadIdentities(IdentityDescriptor[] descriptors, MembershipQuery queryMembership,
+        public TeamFoundationIdentity[] ReadIdentities(IdentityDescriptor[] descriptors, TeamFoundation.Framework.Common.MembershipQuery queryMembership,
             ReadIdentityOptions readOptions)
         {
             return GetNullIdentities();
         }
 
-        public TeamFoundationIdentity ReadIdentity(IdentityDescriptor descriptor, MembershipQuery queryMembership,
+        public TeamFoundationIdentity ReadIdentity(IdentityDescriptor descriptor, TeamFoundation.Framework.Common.MembershipQuery queryMembership,
             ReadIdentityOptions readOptions)
         {
             throw new NotImplementedException();
         }
 
-        public TeamFoundationIdentity[] ReadIdentities(Guid[] teamFoundationIds, MembershipQuery queryMembership)
+        public TeamFoundationIdentity[] ReadIdentities(Guid[] teamFoundationIds, TeamFoundation.Framework.Common.MembershipQuery queryMembership)
         {
             throw new NotImplementedException();
         }
 
         public TeamFoundationIdentity[][] ReadIdentities(TeamFoundation.Framework.Common.IdentitySearchFactor searchFactor, string[] searchFactorValues,
-            MembershipQuery queryMembership, ReadIdentityOptions readOptions)
+            TeamFoundation.Framework.Common.MembershipQuery queryMembership, ReadIdentityOptions readOptions)
         {
             return new []{ GetNullIdentities() };
         }
 
         public TeamFoundationIdentity ReadIdentity(TeamFoundation.Framework.Common.IdentitySearchFactor searchFactor, string searchFactorValue,
-            MembershipQuery queryMembership, ReadIdentityOptions readOptions)
-        {
-            throw new NotImplementedException();
-        }
-
-        public TeamFoundationIdentity[][] ReadIdentities(IdentitySearchFactor searchFactor, string[] searchFactorValues,
-            MembershipQuery queryMembership, ReadIdentityOptions readOptions)
-        {
-            throw new NotImplementedException();
-        }
-
-        public TeamFoundationIdentity ReadIdentity(IdentitySearchFactor searchFactor, string searchFactorValue,
-            MembershipQuery queryMembership, ReadIdentityOptions readOptions)
+            TeamFoundation.Framework.Common.MembershipQuery queryMembership, ReadIdentityOptions readOptions)
         {
             throw new NotImplementedException();
         }
@@ -162,8 +150,33 @@ namespace Microsoft.IE.Qwiq.Core.Tests.Mocks
             throw new NotImplementedException();
         }
 
+        public TeamFoundationIdentity[] ReadIdentities(IdentityDescriptor[] descriptors, TeamFoundation.Framework.Common.MembershipQuery queryMembership,
+            ReadIdentityOptions readOptions, IEnumerable<string> propertyNameFilters, IdentityPropertyScope propertyScope)
+        {
+            throw new NotImplementedException();
+        }
+
+        public TeamFoundationIdentity ReadIdentity(IdentityDescriptor descriptor, TeamFoundation.Framework.Common.MembershipQuery queryMembership,
+            ReadIdentityOptions readOptions, IEnumerable<string> propertyNameFilters, IdentityPropertyScope propertyScope)
+        {
+            throw new NotImplementedException();
+        }
+
+        public TeamFoundationIdentity[] ReadIdentities(Guid[] teamFoundationIds, TeamFoundation.Framework.Common.MembershipQuery queryMembership,
+            ReadIdentityOptions readOptions, IEnumerable<string> propertyNameFilters, IdentityPropertyScope propertyScope)
+        {
+            throw new NotImplementedException();
+        }
+
+        public TeamFoundationIdentity[][] ReadIdentities(TeamFoundation.Framework.Common.IdentitySearchFactor searchFactor, string[] searchFactorValues,
+            TeamFoundation.Framework.Common.MembershipQuery queryMembership, ReadIdentityOptions readOptions, IEnumerable<string> propertyNameFilters,
+            IdentityPropertyScope propertyScope)
+        {
+            throw new NotImplementedException();
+        }
+
         public TeamFoundationIdentity ReadIdentity(TeamFoundation.Framework.Common.IdentitySearchFactor searchFactor, string searchFactorValue,
-            MembershipQuery queryMembership, ReadIdentityOptions readOptions, IEnumerable<string> propertyNameFilters,
+            TeamFoundation.Framework.Common.MembershipQuery queryMembership, ReadIdentityOptions readOptions, IEnumerable<string> propertyNameFilters,
             IdentityPropertyScope propertyScope)
         {
             throw new NotImplementedException();
@@ -171,45 +184,6 @@ namespace Microsoft.IE.Qwiq.Core.Tests.Mocks
 
         public TeamFoundationIdentity[] ListApplicationGroups(string scopeId, ReadIdentityOptions readOptions,
             IEnumerable<string> propertyNameFilters, IdentityPropertyScope propertyScope)
-        {
-            throw new NotImplementedException();
-        }
-
-        public TeamFoundationIdentity ReadIdentity(IdentitySearchFactor searchFactor, string searchFactorValue,
-            MembershipQuery queryMembership, ReadIdentityOptions readOptions, IEnumerable<string> propertyNameFilters,
-            IdentityPropertyScope propertyScope)
-        {
-            throw new NotImplementedException();
-        }
-
-        public TeamFoundationIdentity[][] ReadIdentities(IdentitySearchFactor searchFactor, string[] searchFactorValues,
-            MembershipQuery queryMembership, ReadIdentityOptions readOptions, IEnumerable<string> propertyNameFilters,
-            IdentityPropertyScope propertyScope)
-        {
-            throw new NotImplementedException();
-        }
-
-        public TeamFoundationIdentity[] ReadIdentities(Guid[] teamFoundationIds, MembershipQuery queryMembership,
-            ReadIdentityOptions readOptions, IEnumerable<string> propertyNameFilters, IdentityPropertyScope propertyScope)
-        {
-            throw new NotImplementedException();
-        }
-
-        public TeamFoundationIdentity[][] ReadIdentities(TeamFoundation.Framework.Common.IdentitySearchFactor searchFactor, string[] searchFactorValues,
-            MembershipQuery queryMembership, ReadIdentityOptions readOptions, IEnumerable<string> propertyNameFilters,
-            IdentityPropertyScope propertyScope)
-        {
-            throw new NotImplementedException();
-        }
-
-        public TeamFoundationIdentity ReadIdentity(IdentityDescriptor descriptor, MembershipQuery queryMembership,
-            ReadIdentityOptions readOptions, IEnumerable<string> propertyNameFilters, IdentityPropertyScope propertyScope)
-        {
-            throw new NotImplementedException();
-        }
-
-        public TeamFoundationIdentity[] ReadIdentities(IdentityDescriptor[] descriptors, MembershipQuery queryMembership,
-            ReadIdentityOptions readOptions, IEnumerable<string> propertyNameFilters, IdentityPropertyScope propertyScope)
         {
             throw new NotImplementedException();
         }

--- a/Qwiq/Qwiq.Core/IIdentityManagementService.cs
+++ b/Qwiq/Qwiq.Core/IIdentityManagementService.cs
@@ -4,9 +4,9 @@ namespace Microsoft.IE.Qwiq
 {
     public interface IIdentityManagementService
     {
-        IEnumerable<ITeamFoundationIdentity> ReadIdentities(IEnumerable<IIdentityDescriptor> descriptors);
+        IEnumerable<ITeamFoundationIdentity> ReadIdentities(IEnumerable<IIdentityDescriptor> descriptors, MembershipQuery membershipQuery);
         IEnumerable<ITeamFoundationIdentity> ReadIdentities(IdentitySearchFactor searchFactor,
-            string[] searchFactorValues);
+            string[] searchFactorValues, MembershipQuery membershipQuery);
 
         IIdentityDescriptor CreateIdentityDescriptor(string identityType, string identifier);
     }

--- a/Qwiq/Qwiq.Core/MembershipQuery.cs
+++ b/Qwiq/Qwiq.Core/MembershipQuery.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.IE.Qwiq
+{
+    public enum MembershipQuery
+    {
+        None = 0,
+        Direct = 1,
+        Expanded = 2,
+        ExpandedUp = 3,
+        ExpandedDown = 4
+    }
+}

--- a/Qwiq/Qwiq.Core/Properties/AssemblyInfo.cs
+++ b/Qwiq/Qwiq.Core/Properties/AssemblyInfo.cs
@@ -32,8 +32,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.3.0.0")]
-[assembly: AssemblyFileVersion("4.3.0.0")]
-[assembly: AssemblyInformationalVersion("4.3.0")]
+[assembly: AssemblyVersion("5.0.0.0")]
+[assembly: AssemblyFileVersion("5.0.0.0")]
+[assembly: AssemblyInformationalVersion("5.0.0")]
 
 [assembly: InternalsVisibleTo("Microsoft.IE.Qwiq.Core.Tests")]

--- a/Qwiq/Qwiq.Core/Proxies/IdentityManagementServiceProxy.cs
+++ b/Qwiq/Qwiq.Core/Proxies/IdentityManagementServiceProxy.cs
@@ -14,22 +14,25 @@ namespace Microsoft.IE.Qwiq.Proxies
             _identityManagementService2 = identityManagementService2;
         }
 
-        public IEnumerable<ITeamFoundationIdentity> ReadIdentities(IEnumerable<IIdentityDescriptor> descriptors)
+        public IEnumerable<ITeamFoundationIdentity> ReadIdentities(IEnumerable<IIdentityDescriptor> descriptors, MembershipQuery membershipQuery)
         {
             var rawDescriptors = descriptors.Select(descriptor =>
                 new Tfs.Client.IdentityDescriptor(descriptor.IdentityType, descriptor.Identifier)).ToArray();
+            var membership = (Tfs.Common.MembershipQuery) membershipQuery;
 
-            var identities = _identityManagementService2.ReadIdentities(rawDescriptors, Tfs.Common.MembershipQuery.None,
+            var identities = _identityManagementService2.ReadIdentities(rawDescriptors, membership,
                 Tfs.Common.ReadIdentityOptions.None);
 
             return identities.Select(identity => identity == null ? null : ExceptionHandlingDynamicProxyFactory.Create<ITeamFoundationIdentity>(new TeamFoundationIdentityProxy(identity)));
         }
 
-        public IEnumerable<ITeamFoundationIdentity> ReadIdentities(IdentitySearchFactor searchFactor, string[] searchFactorValues)
+        public IEnumerable<ITeamFoundationIdentity> ReadIdentities(IdentitySearchFactor searchFactor, string[] searchFactorValues, MembershipQuery membershipQuery)
         {
             var factor = (Tfs.Common.IdentitySearchFactor) searchFactor;
+            var membership = (Tfs.Common.MembershipQuery) membershipQuery;
+
             var identities = _identityManagementService2.ReadIdentities(factor, searchFactorValues,
-                Tfs.Common.MembershipQuery.None, Tfs.Common.ReadIdentityOptions.None)[0];
+                membership, Tfs.Common.ReadIdentityOptions.None)[0];
 
             return identities.Select(identity => identity == null ? null : ExceptionHandlingDynamicProxyFactory.Create<ITeamFoundationIdentity>(new TeamFoundationIdentityProxy(identity)));
         }

--- a/Qwiq/Qwiq.Core/Qwiq.Core.csproj
+++ b/Qwiq/Qwiq.Core/Qwiq.Core.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Exceptions\VssExceptionMapper.cs" />
     <Compile Include="IQuery.cs" />
     <Compile Include="LinkMapper.cs" />
+    <Compile Include="MembershipQuery.cs" />
     <Compile Include="Proxies\IdentityDescriptorProxy.cs" />
     <Compile Include="IdentitySearchFactor.cs" />
     <Compile Include="IField.cs" />


### PR DESCRIPTION
- Expose the `MembershipQuery` enum on `IdentityManagementService2`'s
  `ReadIdentities` instead of always making it `None`
- Update mocks
- Update unit tests
