### PR TITLE
Update Map method to handle exception

### DIFF
--- a/Qwiq/Qwiq.Mapper/Attributes/AttributeMapperStrategy.cs
+++ b/Qwiq/Qwiq.Mapper/Attributes/AttributeMapperStrategy.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using Microsoft.TeamFoundation.WorkItemTracking.Client;
 
 namespace Microsoft.IE.Qwiq.Mapper.Attributes
 {
@@ -22,8 +23,21 @@ namespace Microsoft.IE.Qwiq.Mapper.Attributes
                 var field = _inspector.GetAttribute<FieldDefinitionAttribute>(property);
                 if (field != null)
                 {
-                    var value = ParseValue(property, sourceWorkItem[field.GetFieldName()]);
-                    property.SetValue(targetWorkItem, value);
+                    var fieldName = field.GetFieldName();
+
+                    try
+                    {
+                        var value = ParseValue(property, sourceWorkItem[fieldName]);
+                        property.SetValue(targetWorkItem, value);
+                    }
+                    catch (FieldDefinitionNotExistException e)
+                    {
+                        System.Diagnostics.Trace.TraceWarning("Could not map field '{0}' from type '{1}' to type '{2}'. {3}",
+                            fieldName,
+                            sourceWorkItem.Type.Name,
+                            targetWorkItemType.Name,
+                            e.Message);
+                    }
                 }
             }
         }

--- a/Qwiq/Qwiq.Mapper/Qwiq.Mapper.csproj
+++ b/Qwiq/Qwiq.Mapper/Qwiq.Mapper.csproj
@@ -43,6 +43,18 @@
       <HintPath>..\packages\Microsoft.IE.Qwiq.Core.4.0.1.1\lib\net45\Microsoft.IE.Qwiq.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.TeamFoundation.Common, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\TFS\Microsoft.TeamFoundation.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.TeamFoundation.WorkItemTracking.Client, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\TFS\Microsoft.TeamFoundation.WorkItemTracking.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Services.Common, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\TFS\Microsoft.VisualStudio.Services.Common.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>


### PR DESCRIPTION
Fixes #38

During a Map operation, if the requested field does not exist on the target WIT, an unhandled FieldDefinitionNotExistException is thrown.

Product Owner: @pelavall 
Code Review: @MicrosoftEdge/ieportal-qwiq-admins 
