### PR TITLE
Update Map method to handle exception

### DIFF
--- a/Qwiq/Qwiq.Mapper/Properties/AssemblyInfo.cs
+++ b/Qwiq/Qwiq.Mapper/Properties/AssemblyInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
-[assembly: AssemblyInformationalVersion("2.0.0")]
+[assembly: AssemblyVersion("2.1.0.0")]
+[assembly: AssemblyFileVersion("2.1.0.0")]
+[assembly: AssemblyInformationalVersion("2.1.0")]

--- a/Qwiq/Qwiq.Mapper/Qwiq.Mapper.csproj
+++ b/Qwiq/Qwiq.Mapper/Qwiq.Mapper.csproj
@@ -12,8 +12,7 @@
     <AssemblyName>Microsoft.IE.Qwiq.Mapper</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>23bfbead</NuGetPackageImportStamp>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
@@ -66,11 +65,6 @@
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.2\lib\net45\System.Net.Http.Formatting.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Attributes\AttributeMapperStrategy.cs" />
@@ -96,19 +90,21 @@
     <Compile Include="TypeParser.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
+    <None Include="Qwiq.Mapper.nuspec" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.IE.Qwiq.Core.4.0.1.1\build\microsoft.ie.qwiq.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.IE.Qwiq.Core.4.0.1.1\build\microsoft.ie.qwiq.core.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.IE.Qwiq.Core.4.0.1.1\build\microsoft.ie.qwiq.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.IE.Qwiq.Core.4.0.1.1\build\microsoft.ie.qwiq.core.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
-  <Import Project="..\packages\Microsoft.IE.Qwiq.Core.4.0.1.1\build\microsoft.ie.qwiq.core.targets" Condition="Exists('..\packages\Microsoft.IE.Qwiq.Core.4.0.1.1\build\microsoft.ie.qwiq.core.targets')" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Import Project="..\packages\Microsoft.IE.Qwiq.Core.4.0.1.1\build\microsoft.ie.qwiq.core.targets" Condition="Exists('..\packages\Microsoft.IE.Qwiq.Core.4.0.1.1\build\microsoft.ie.qwiq.core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Qwiq/Qwiq.Mapper/Qwiq.Mapper.nuspec
+++ b/Qwiq/Qwiq.Mapper/Qwiq.Mapper.nuspec
@@ -1,13 +1,21 @@
 <?xml version="1.0"?>
-<package >
+<package>
   <metadata>
     <id>$id$</id>
     <version>$version$</version>
     <title>$title$</title>
     <authors>$author$</authors>
-    <owners>$author$</owners>
+    <owners>$author$, Microsoft</owners>
+    <projectUrl>https://github.com/MicrosoftEdge/IEPortal.Qwiq</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>$description$</description>
+    <tags>IE IEPortal MS Internal Only MicrosoftEdge WebPlatform WebPlatformServices</tags>
+    <dependencies>
+      <dependency id="JB.Tfs.Common" version="[0.0.0.5,)"/>
+      <dependency id="Microsoft.AspNet.WebApi.Client" version="[5.2.2,)"/>
+      <dependency id="Microsoft.IE.Qwiq.Core" version="4.0.1.1" />
+      <dependency id="Newtonsoft.Json" version="6.0.4" />
+    </dependencies>
   </metadata>
   <files />
 </package>

--- a/Qwiq/Qwiq.Mapper/app.config
+++ b/Qwiq/Qwiq.Mapper/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.TeamFoundation.WorkItemTracking.Client" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-14.0.0.0" newVersion="14.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
During a Map operation, if the requested field does not exist on the target WIT, an unhandled FieldDefinitionNotExistException is thrown.

Fixes #38 
Connected to #40

Product Owner: @pelavall 
Code Review: @MicrosoftEdge/ieportal-qwiq-admins 
