### PR TITLE
Fix Identity Aware Mapper to return original value if null or empty

### DIFF
--- a/Qwiq/Qwiq.Identity.Tests/IdentityAwareAttributeMapperStrategyTests.cs
+++ b/Qwiq/Qwiq.Identity.Tests/IdentityAwareAttributeMapperStrategyTests.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.IE.IEPortal.BehaviorDrivenDevelopmentTools;
+using Microsoft.IE.Qwiq;
+using Microsoft.IE.Qwiq.Identity.Attributes;
+using Microsoft.IE.Qwiq.Mapper;
+using Microsoft.IE.Qwiq.Mapper.Attributes;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Qwiq.Identity.Tests.Mocks;
+
+namespace Qwiq.Identity.Tests
+{
+    public abstract class IdentityAwareAttributeMapperStrategyTests : ContextSpecification
+    {
+        private IWorkItemMapperStrategy _strategy;
+        private IEnumerable<KeyValuePair<IWorkItem, object>> _workItemMappings;
+
+        protected MockIdentityType Actual
+        {
+            get { return _workItemMappings.Select(kvp => kvp.Value).Cast<MockIdentityType>().Single(); }
+        }
+
+        protected string IdentityFieldBackingValue { get; set; }
+
+
+        public override void Given()
+        {
+            var propertyInspector = new PropertyInspector(new PropertyReflector());
+            var typeParser = new TypeParser();
+            _strategy = new IdentityAwareAttributeMapperStrategy(propertyInspector, typeParser, new MockIdentityManagementService());
+            var sourceWorkItems = new[]
+            {
+                new MockWorkItem
+                {
+                    Properties = new Dictionary<string, object>
+                    {
+                        { MockIdentityType.BackingField, IdentityFieldBackingValue }
+                    }
+                }
+            };
+
+            _workItemMappings = sourceWorkItems.Select(t => new KeyValuePair<IWorkItem, object>(t, new MockIdentityType())).ToList();
+        }
+
+        public override void When()
+        {
+            _strategy.Map(typeof (MockIdentityType), _workItemMappings, null);
+        }
+    }
+
+    [TestClass]
+    public class when_a_backing_source_is_the_empty_string_the_field_should_be_mapped_with_the_original_value : IdentityAwareAttributeMapperStrategyTests
+    {
+        public override void Given()
+        {
+            IdentityFieldBackingValue = string.Empty;
+            base.Given();
+        }
+
+        [TestMethod]
+        public void the_actual_identity_value_is_the_original_value()
+        {
+            Actual.AnIdentity.ShouldEqual(IdentityFieldBackingValue);
+        }
+    }
+}

--- a/Qwiq/Qwiq.Identity.Tests/MockIdentityManagementService.cs
+++ b/Qwiq/Qwiq.Identity.Tests/MockIdentityManagementService.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.IE.Qwiq;
+
+namespace Qwiq.Identity.Tests
+{
+    public class MockIdentityManagementService : IIdentityManagementService
+    {
+        public IEnumerable<ITeamFoundationIdentity> ReadIdentities(IEnumerable<IIdentityDescriptor> descriptors)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<ITeamFoundationIdentity> ReadIdentities(IdentitySearchFactor searchFactor, string[] searchFactorValues)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IIdentityDescriptor CreateIdentityDescriptor(string identityType, string identifier)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Qwiq/Qwiq.Identity.Tests/Mocks/IdentityMockType.cs
+++ b/Qwiq/Qwiq.Identity.Tests/Mocks/IdentityMockType.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.IE.Qwiq.Identity.Attributes;
+using Microsoft.IE.Qwiq.Mapper.Attributes;
+
+namespace Qwiq.Identity.Tests.Mocks
+{
+    public class MockIdentityType
+    {
+        public const string BackingField = "Identity Field";
+
+        [FieldDefinition(BackingField)]
+        [IdentityField]
+        public string AnIdentity { get; set; }
+    }
+}

--- a/Qwiq/Qwiq.Identity.Tests/Mocks/MockField.cs
+++ b/Qwiq/Qwiq.Identity.Tests/Mocks/MockField.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.IE.Qwiq;
+
+namespace Qwiq.Identity.Tests.Mocks
+{
+    public class MockField : IField
+    {
+        public int Id { get; set; }
+        public bool IsDirty { get; set; }
+        public bool IsEditable { get; set; }
+        public bool IsRequired { get; set; }
+        public bool IsValid { get; set; }
+        public string Name { get; set; }
+        public object OriginalValue { get; set; }
+        public ValidationState ValidationState { get; set; }
+        public object Value { get; set; }
+    }
+}

--- a/Qwiq/Qwiq.Identity.Tests/Mocks/MockWorkItem.cs
+++ b/Qwiq/Qwiq.Identity.Tests/Mocks/MockWorkItem.cs
@@ -1,0 +1,223 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.IE.Qwiq;
+
+namespace Qwiq.Identity.Tests.Mocks
+{
+    public class MockWorkItem : IWorkItem
+    {
+        public Dictionary<string, object> Properties { get; set; }
+
+        public string AssignedTo
+        {
+            get { throw new NotImplementedException(); }
+            set { throw new NotImplementedException(); }
+        }
+
+        public string AreaPath
+        {
+            get { throw new NotImplementedException(); }
+            set { throw new NotImplementedException(); }
+        }
+
+        public int AttachedFileCount
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public string ChangedBy
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public DateTime ChangedDate
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public void Close()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IWorkItem Copy()
+        {
+            throw new NotImplementedException();
+        }
+
+        public string CreatedBy
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public DateTime CreatedDate
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public string Description
+        {
+            get { throw new NotImplementedException(); }
+            set { throw new NotImplementedException(); }
+        }
+
+        public int ExternalLinkCount
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IEnumerable<IField> Fields
+        {
+            get { return Properties.Select(p => new MockField {Name = p.Key, Value = p.Value}); }
+        }
+
+        public string History
+        {
+            get { throw new NotImplementedException(); }
+            set { throw new NotImplementedException(); }
+        }
+
+        public int HyperLinkCount
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public int Id { get; set; }
+
+        public bool IsValid()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsDirty
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public string IterationPath
+        {
+            get { throw new NotImplementedException(); }
+            set { throw new NotImplementedException(); }
+        }
+
+        public void Open()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void PartialOpen()
+        {
+            throw new NotImplementedException();
+        }
+
+        public int RelatedLinkCount
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public void Reset()
+        {
+            throw new NotImplementedException();
+        }
+
+        public DateTime RevisedDate
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public int Revision
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IEnumerable<IRevision> Revisions
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public void Save()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Save(SaveFlags saveFlags)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string State
+        {
+            get { throw new NotImplementedException(); }
+            set { throw new NotImplementedException(); }
+        }
+
+        public string Tags
+        {
+            get { throw new NotImplementedException(); }
+            set { throw new NotImplementedException(); }
+        }
+
+        public string Keywords
+        {
+            get { throw new NotImplementedException(); }
+            set { throw new NotImplementedException(); }
+        }
+
+        public object this[string name]
+        {
+            get { return Properties[name]; }
+            set { Properties[name] = value; }
+        }
+
+        public string Title
+        {
+            get { throw new NotImplementedException(); }
+            set { throw new NotImplementedException(); }
+        }
+
+        public Uri Uri
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IEnumerable<IField> Validate()
+        {
+            throw new NotImplementedException();
+        }
+
+        public ICollection<ILink> Links
+        {
+            get { return new List<ILink>(); }
+        }
+
+        public IEnumerable<IAttachment> Attachments
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IWorkItemType Type { get; set; }
+
+        public IEnumerable<IWorkItemLink> WorkItemLinks { get; set; }
+
+        public int Rev
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IRelatedLink CreateRelatedLink(IWorkItemLinkTypeEnd end, IWorkItem relatedWorkItem)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IHyperlink CreateHyperlink(string location)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IWorkItemLink CreateWorkItemLink(IWorkItemLinkTypeEnd end, IWorkItem targetWorkItem)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Qwiq/Qwiq.Identity.Tests/Qwiq.Identity.Tests.csproj
+++ b/Qwiq/Qwiq.Identity.Tests/Qwiq.Identity.Tests.csproj
@@ -245,6 +245,11 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="IdentityAwareAttributeMapperStrategyTests.cs" />
+    <Compile Include="MockIdentityManagementService.cs" />
+    <Compile Include="Mocks\IdentityMockType.cs" />
+    <Compile Include="Mocks\MockField.cs" />
+    <Compile Include="Mocks\MockWorkItem.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -255,6 +260,10 @@
     <ProjectReference Include="..\Qwiq.Identity\Qwiq.Identity.csproj">
       <Project>{b3654d2d-b4d4-405c-9aec-fc1859a87e74}</Project>
       <Name>Qwiq.Identity</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Qwiq.Mapper\Qwiq.Mapper.csproj">
+      <Project>{016e8d93-4195-4639-bcd5-77633e8e1681}</Project>
+      <Name>Qwiq.Mapper</Name>
     </ProjectReference>
   </ItemGroup>
   <Choose>

--- a/Qwiq/Qwiq.Identity/Attributes/IdentityAwareAttributeMapperStrategy.cs
+++ b/Qwiq/Qwiq.Identity/Attributes/IdentityAwareAttributeMapperStrategy.cs
@@ -21,19 +21,22 @@ namespace Microsoft.IE.Qwiq.Identity.Attributes
         {
             value = base.ParseValue(property, value);
             var identityField = _inspector.GetAttribute<IdentityFieldAttribute>(property);
-            if (identityField != null && value != null)
+            if (identityField == null || value == null)
             {
-                var displayName = value.ToString();
-                var alias = _identityMapper
-                                .GetAliasesForDisplayName(displayName)
-                                .FirstOrDefault();
-
-                if (!string.IsNullOrEmpty(alias))
-                {
-                    value = alias;
-                }
+                return value;
             }
-            return value;
+
+            var displayName = value.ToString();
+            if (string.IsNullOrEmpty(displayName))
+            {
+                return value;
+            }
+
+            var alias = _identityMapper
+                .GetAliasesForDisplayName(displayName)
+                .FirstOrDefault();
+
+            return string.IsNullOrEmpty(alias) ? value : alias;
         }
     }
 }


### PR DESCRIPTION
```
- Not having this behavior was causing a large number of
```

exceptions to be caught and traced in production.
