### PR TITLE
Ensure WitDatastore dlls from TFS are packaged

### DIFF
--- a/Qwiq/Qwiq.Core/Properties/AssemblyInfo.cs
+++ b/Qwiq/Qwiq.Core/Properties/AssemblyInfo.cs
@@ -32,8 +32,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.0.1.0")]
-[assembly: AssemblyFileVersion("5.0.1.0")]
-[assembly: AssemblyInformationalVersion("5.0.1")]
+[assembly: AssemblyVersion("5.0.2.0")]
+[assembly: AssemblyFileVersion("5.0.2.0")]
+[assembly: AssemblyInformationalVersion("5.0.2")]
 
 [assembly: InternalsVisibleTo("Microsoft.IE.Qwiq.Core.Tests")]

--- a/Qwiq/Qwiq.Core/Qwiq.Core.csproj
+++ b/Qwiq/Qwiq.Core/Qwiq.Core.csproj
@@ -313,6 +313,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="microsoft.ie.qwiq.core.props" />
     <None Include="packages.config" />
     <None Include="Qwiq.Core.nuspec" />
   </ItemGroup>

--- a/Qwiq/Qwiq.Core/Qwiq.Core.nuspec
+++ b/Qwiq/Qwiq.Core/Qwiq.Core.nuspec
@@ -11,5 +11,11 @@
     <description>$description$</description>
     <copyright>$copyright$</copyright>
     <tags>IE IEPortal MS Internal Only MicrosoftEdge WebPlatform WebPlatformServices</tags>
+    <dependencies>
+        <dependency id="Microsoft.TeamFoundationServer.ExtendedClient" version="[14.89.0]" />
+    </dependencies>
   </metadata>
+  <files>
+    <file src="microsoft.ie.qwiq.core.props" target="build" />
+  </files>
 </package>

--- a/Qwiq/Qwiq.Core/microsoft.ie.qwiq.core.props
+++ b/Qwiq/Qwiq.Core/microsoft.ie.qwiq.core.props
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Content Include="$(MSBuildThisFileDirectory)\..\..\Microsoft.TeamFoundationServer.ExtendedClient.14.89.0\lib\native\x86\Microsoft.WITDataStore32.dll">
+      <Link>Microsoft.WITDataStore32.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)\..\..\Microsoft.TeamFoundationServer.ExtendedClient.14.89.0\lib\native\amd64\Microsoft.WITDataStore64.dll">
+      <Link>Microsoft.WITDataStore64.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </Content>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
In an azure environment there is a publishing step. The publishing step only includes detectable references, because the datastore binaries are run time loaded they aren't detected and aren't packaged. This change includes the files explicity in the project so they are included. To ensure we know where the binaries are we have to take a strict dependency on the version of tfs we use.

This fixes #57.
