### PR TITLE
Update Relatives to Linq 2.0.1

### DIFF
--- a/Qwiq/Qwiq.Relatives.Tests/Qwiq.Relatives.Tests.csproj
+++ b/Qwiq/Qwiq.Relatives.Tests/Qwiq.Relatives.Tests.csproj
@@ -39,28 +39,28 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=2.23.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.23.302261847\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=2.16.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.16.204221202\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms, Version=2.23.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.23.302261847\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms, Version=2.16.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.16.204221202\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.IE.IEPortal.BehaviorDrivenDevelopmentTools, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)packages\Microsoft.IE.IEPortal.BehaviorDrivenDevelopmentTools.2.1.0.0\lib\net45\Microsoft.IE.IEPortal.BehaviorDrivenDevelopmentTools.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.IE.Qwiq.Core, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IE.Qwiq.Core.5.0.0\lib\net45\Microsoft.IE.Qwiq.Core.dll</HintPath>
+    <Reference Include="Microsoft.IE.Qwiq.Core, Version=5.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IE.Qwiq.Core.5.0.1\lib\net45\Microsoft.IE.Qwiq.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.IE.Qwiq.Linq, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IE.Qwiq.Linq.2.0.0\lib\net45\Microsoft.IE.Qwiq.Linq.dll</HintPath>
+    <Reference Include="Microsoft.IE.Qwiq.Linq, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IE.Qwiq.Linq.2.0.1\lib\net45\Microsoft.IE.Qwiq.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.IE.Qwiq.Mapper, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IE.Qwiq.Mapper.3.0.1\lib\net45\Microsoft.IE.Qwiq.Mapper.dll</HintPath>
+    <Reference Include="Microsoft.IE.Qwiq.Mapper, Version=3.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IE.Qwiq.Mapper.3.0.2\lib\net45\Microsoft.IE.Qwiq.Mapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ServiceBus, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Qwiq/Qwiq.Relatives.Tests/app.config
+++ b/Qwiq/Qwiq.Relatives.Tests/app.config
@@ -1,21 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  
-  
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.23.0.0" newVersion="2.23.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.TeamFoundation.WorkItemTracking.Client" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-14.0.0.0" newVersion="14.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.TeamFoundation.Client" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-14.0.0.0" newVersion="14.0.0.0" />
-      </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />

--- a/Qwiq/Qwiq.Relatives.Tests/packages.config
+++ b/Qwiq/Qwiq.Relatives.Tests/packages.config
@@ -2,11 +2,11 @@
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
-  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.23.302261847" targetFramework="net45" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.16.204221202" targetFramework="net45" />
   <package id="Microsoft.IE.IEPortal.BehaviorDrivenDevelopmentTools" version="2.1.0.0" targetFramework="net45" />
-  <package id="Microsoft.IE.Qwiq.Core" version="5.0.0" targetFramework="net45" />
-  <package id="Microsoft.IE.Qwiq.Linq" version="2.0.0" targetFramework="net45" />
-  <package id="Microsoft.IE.Qwiq.Mapper" version="3.0.1" targetFramework="net45" />
+  <package id="Microsoft.IE.Qwiq.Core" version="5.0.1" targetFramework="net45" />
+  <package id="Microsoft.IE.Qwiq.Linq" version="2.0.1" targetFramework="net45" />
+  <package id="Microsoft.IE.Qwiq.Mapper" version="3.0.2" targetFramework="net45" />
   <package id="Microsoft.TeamFoundationServer.Client" version="14.89.0" targetFramework="net46" />
   <package id="Microsoft.TeamFoundationServer.ExtendedClient" version="14.89.0" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Services.Client" version="14.89.0" targetFramework="net46" />

--- a/Qwiq/Qwiq.Relatives/Properties/AssemblyInfo.cs
+++ b/Qwiq/Qwiq.Relatives/Properties/AssemblyInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.0.0")]
-[assembly: AssemblyFileVersion("0.2.0.0")]
-[assembly: AssemblyInformationalVersion("0.2.0")]
+[assembly: AssemblyVersion("0.2.1.0")]
+[assembly: AssemblyFileVersion("0.2.1.0")]
+[assembly: AssemblyInformationalVersion("0.2.1")]

--- a/Qwiq/Qwiq.Relatives/Qwiq.Relatives.csproj
+++ b/Qwiq/Qwiq.Relatives/Qwiq.Relatives.csproj
@@ -34,24 +34,24 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=2.23.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.23.302261847\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=2.16.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.16.204221202\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms, Version=2.23.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.23.302261847\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms, Version=2.16.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.16.204221202\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.IE.Qwiq.Core, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IE.Qwiq.Core.5.0.0\lib\net45\Microsoft.IE.Qwiq.Core.dll</HintPath>
+    <Reference Include="Microsoft.IE.Qwiq.Core, Version=5.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IE.Qwiq.Core.5.0.1\lib\net45\Microsoft.IE.Qwiq.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.IE.Qwiq.Linq, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IE.Qwiq.Linq.2.0.0\lib\net45\Microsoft.IE.Qwiq.Linq.dll</HintPath>
+    <Reference Include="Microsoft.IE.Qwiq.Linq, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IE.Qwiq.Linq.2.0.1\lib\net45\Microsoft.IE.Qwiq.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.IE.Qwiq.Mapper, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IE.Qwiq.Mapper.3.0.1\lib\net45\Microsoft.IE.Qwiq.Mapper.dll</HintPath>
+    <Reference Include="Microsoft.IE.Qwiq.Mapper, Version=3.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IE.Qwiq.Mapper.3.0.2\lib\net45\Microsoft.IE.Qwiq.Mapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ServiceBus, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Qwiq/Qwiq.Relatives/app.config
+++ b/Qwiq/Qwiq.Relatives/app.config
@@ -11,20 +11,8 @@
         <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.23.0.0" newVersion="2.23.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.ServiceBus" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.TeamFoundation.WorkItemTracking.Client" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-14.0.0.0" newVersion="14.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.TeamFoundation.Client" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-14.0.0.0" newVersion="14.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Qwiq/Qwiq.Relatives/packages.config
+++ b/Qwiq/Qwiq.Relatives/packages.config
@@ -2,10 +2,10 @@
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
-  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.23.302261847" targetFramework="net45" />
-  <package id="Microsoft.IE.Qwiq.Core" version="5.0.0" targetFramework="net45" />
-  <package id="Microsoft.IE.Qwiq.Linq" version="2.0.0" targetFramework="net45" />
-  <package id="Microsoft.IE.Qwiq.Mapper" version="3.0.1" targetFramework="net45" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.16.204221202" targetFramework="net45" />
+  <package id="Microsoft.IE.Qwiq.Core" version="5.0.1" targetFramework="net45" />
+  <package id="Microsoft.IE.Qwiq.Linq" version="2.0.1" targetFramework="net45" />
+  <package id="Microsoft.IE.Qwiq.Mapper" version="3.0.2" targetFramework="net45" />
   <package id="Microsoft.TeamFoundationServer.Client" version="14.89.0" targetFramework="net45" />
   <package id="Microsoft.TeamFoundationServer.ExtendedClient" version="14.89.0" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Services.Client" version="14.89.0" targetFramework="net45" />


### PR DESCRIPTION
This includes the downgrade in dependency from
    activedirectory 2.23 to 2.16
