### PR TITLE
Update IdentityVisitor GetDisplayName to return a string

### DIFF
--- a/Qwiq/Qwiq.Identity/Linq/Visitors/IdentityVisitor.cs
+++ b/Qwiq/Qwiq.Identity/Linq/Visitors/IdentityVisitor.cs
@@ -69,7 +69,7 @@ namespace Microsoft.IE.Qwiq.Identity.Linq.Visitors
             return expressions.OfType<MemberExpression>().Any(arg => IsIdentityField(arg.Expression.Type, arg.Member.Name));
         }
 
-        private object GetDisplayName(string alias)
+        private string GetDisplayName(string alias)
         {
             try
             {
@@ -85,9 +85,13 @@ namespace Microsoft.IE.Qwiq.Identity.Linq.Visitors
 
         private object ReplaceValue(object value)
         {
-            return value is string
-                ? GetDisplayName(value.ToString())
-                : ((IEnumerable<string>)value)?.Select(GetDisplayName);
+            if (value is string)
+            {
+                return GetDisplayName(value.ToString());
+            }
+
+            var stringArray = value as IEnumerable<string>;
+            return stringArray?.Select(GetDisplayName) ?? value;
         }
     }
 }

--- a/Qwiq/Qwiq.Identity/Properties/AssemblyInfo.cs
+++ b/Qwiq/Qwiq.Identity/Properties/AssemblyInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.2.0")]
-[assembly: AssemblyFileVersion("2.0.2.0")]
-[assembly: AssemblyInformationalVersion("2.0.2")]
+[assembly: AssemblyVersion("2.0.3.0")]
+[assembly: AssemblyFileVersion("2.0.3.0")]
+[assembly: AssemblyInformationalVersion("2.0.3-alpha")]


### PR DESCRIPTION
- This change forces the return type in the case of
  an IEnumerable<string> to return a statement which resolves to
  IEnumerable<string> rather than object which later on in the
  evaluation will allow for proper assignment. Before this update
  when this code was executed it would throw an invalid cast exception
  further along in the evaluation of the visit.
