### PR TITLE
Add IEnumerable<IField> interface to IFieldCollection

### DIFF
--- a/Qwiq/Qwiq.Core/IFieldCollection.cs
+++ b/Qwiq/Qwiq.Core/IFieldCollection.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.IE.Qwiq
 {
-    public interface IFieldCollection : IEnumerable
+    public interface IFieldCollection : IEnumerable, IEnumerable<IField>
     {
         IField this[string name] { get; }
         int Count { get; }

--- a/Qwiq/Qwiq.Core/Properties/AssemblyInfo.cs
+++ b/Qwiq/Qwiq.Core/Properties/AssemblyInfo.cs
@@ -34,6 +34,6 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("6.0.0.0")]
 [assembly: AssemblyFileVersion("6.0.0.0")]
-[assembly: AssemblyInformationalVersion("6.0.3-alpha")]
+[assembly: AssemblyInformationalVersion("6.0.4-alpha")]
 
 [assembly: InternalsVisibleTo("Microsoft.IE.Qwiq.Core.Tests")]

--- a/Qwiq/Qwiq.Core/Proxies/FieldCollectionProxy.cs
+++ b/Qwiq/Qwiq.Core/Proxies/FieldCollectionProxy.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.IE.Qwiq.Exceptions;
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
 
@@ -11,6 +13,11 @@ namespace Microsoft.IE.Qwiq.Proxies
         public FieldCollectionProxy(FieldCollection innerCollection)
         {
             _innerCollection = innerCollection;
+        }
+
+        IEnumerator<IField> IEnumerable<IField>.GetEnumerator()
+        {
+            return _innerCollection.Cast<IField>().GetEnumerator();
         }
 
         public IEnumerator GetEnumerator()


### PR DESCRIPTION
- This enables Linq syntax to be used on IFieldCollections
