### PR TITLE
Update ExceptionHandlingProxy to use CastleCore

### DIFF
--- a/Qwiq/Qwiq.Core.Tests/ExceptionHandlingDynamicProxyTests.cs
+++ b/Qwiq/Qwiq.Core.Tests/ExceptionHandlingDynamicProxyTests.cs
@@ -16,15 +16,13 @@ namespace Microsoft.IE.Qwiq.Core.Tests
         public override void Given()
         {
             ProxiedInstance =
-                new ExceptionHandlingDynamicProxy<IExceptionThrower>(
-                    InstanceToProxy,
-                    new ExceptionMapper(
-                        Enumerable.Empty<IExceptionExploder>(),
-                        new[]
-                        {
-                            new MockArgumentExceptionMapper()
-                        }))
-                .GetTransparentProxy() as IExceptionThrower;
+                ExceptionHandlingDynamicProxyFactory.Create(
+                        InstanceToProxy,
+                            Enumerable.Empty<IExceptionExploder>(),
+                            new[]
+                            {
+                                new MockArgumentExceptionMapper()
+                            });
         }
     }
 

--- a/Qwiq/Qwiq.Core.Tests/Qwiq.Core.Tests.csproj
+++ b/Qwiq/Qwiq.Core.Tests/Qwiq.Core.Tests.csproj
@@ -42,6 +42,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=2.16.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.16.204221202\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
       <Private>True</Private>

--- a/Qwiq/Qwiq.Core.Tests/packages.config
+++ b/Qwiq/Qwiq.Core.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net451" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.16.204221202" targetFramework="net45" />

--- a/Qwiq/Qwiq.Core/Exceptions/ExceptionHandlingDynamicProxy.cs
+++ b/Qwiq/Qwiq.Core/Exceptions/ExceptionHandlingDynamicProxy.cs
@@ -1,34 +1,26 @@
 ﻿using System;
-using System.Reflection;
-using System.Runtime.Remoting.Messaging;
-using System.Runtime.Remoting.Proxies;
+using Castle.DynamicProxy;
 
 namespace Microsoft.IE.Qwiq.Exceptions
 {
-    public class ExceptionHandlingDynamicProxy<T> : RealProxy
+    public class ExceptionHandlingDynamicProxy<T> : IInterceptor
     {
-        private readonly T _decorated;
         private readonly IExceptionMapper _exceptionMapper;
 
-        public ExceptionHandlingDynamicProxy(T decorated, IExceptionMapper exceptionMapper) : base(typeof(T))
+        public ExceptionHandlingDynamicProxy(IExceptionMapper exceptionMapper)
         {
-            _decorated = decorated;
             _exceptionMapper = exceptionMapper;
         }
 
-        public override IMessage Invoke(IMessage msg)
+        public void Intercept(IInvocation invocation)
         {
-            var methodCall = msg as IMethodCallMessage;
-            var methodInfo = methodCall.MethodBase as MethodInfo;
-
             try
             {
-                var result = methodInfo.Invoke(_decorated, methodCall.InArgs);
-                return new ReturnMessage(result, null, 0, methodCall.LogicalCallContext, methodCall);
+                invocation.Proceed();
             }
             catch (Exception e)
             {
-                return new ReturnMessage(_exceptionMapper.Map(e.InnerException), methodCall);
+                throw _exceptionMapper.Map(e);
             }
         }
     }

--- a/Qwiq/Qwiq.Core/Exceptions/ExceptionHandlingDynamicProxyFactory.cs
+++ b/Qwiq/Qwiq.Core/Exceptions/ExceptionHandlingDynamicProxyFactory.cs
@@ -1,14 +1,37 @@
-﻿namespace Microsoft.IE.Qwiq.Exceptions
+﻿using System.Collections.Generic;
+using Castle.DynamicProxy;
+
+namespace Microsoft.IE.Qwiq.Exceptions
 {
     public static class ExceptionHandlingDynamicProxyFactory
     {
+        private static readonly ProxyGenerator Generator = new ProxyGenerator();
+
         public static T Create<T>(T instance) where T : class
         {
-            return new ExceptionHandlingDynamicProxy<T>(
-                instance,
-                new ExceptionMapper(
-                    new IExceptionExploder[] {new AggregateExceptionExploder(), new InnerExceptionExploder()},
-                    new IExceptionMapper[] {new InvalidOperationExceptionMapper(), new TransientExceptionMapper()})).GetTransparentProxy() as T;
+            return Create(
+                    instance,
+                    new IExceptionExploder[]
+                    {
+                        new AggregateExceptionExploder(),
+                        new InnerExceptionExploder()
+                    },
+                    new IExceptionMapper[]
+                    {
+                        new InvalidOperationExceptionMapper(),
+                        new TransientExceptionMapper()
+                    });
+        }
+
+        internal static T Create<T>(T instance, IEnumerable<IExceptionExploder> exploders, IEnumerable<IExceptionMapper> mappers) where T : class
+        {
+            var proxy =
+                new ExceptionHandlingDynamicProxy<T>(
+                    new ExceptionMapper(
+                        exploders,
+                        mappers));
+
+            return (T)Generator.CreateInterfaceProxyWithTarget(typeof(T), instance, proxy);
         }
     }
 }

--- a/Qwiq/Qwiq.Core/Properties/AssemblyInfo.cs
+++ b/Qwiq/Qwiq.Core/Properties/AssemblyInfo.cs
@@ -32,8 +32,10 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.0.1.0")]
-[assembly: AssemblyFileVersion("6.0.1.0")]
-[assembly: AssemblyInformationalVersion("6.0.1")]
+[assembly: AssemblyVersion("6.1.0.0")]
+[assembly: AssemblyFileVersion("6.1.0.0")]
+[assembly: AssemblyInformationalVersion("6.1.0")]
 
 [assembly: InternalsVisibleTo("Microsoft.IE.Qwiq.Core.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2,PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/Qwiq/Qwiq.Core/Qwiq.Core.csproj
+++ b/Qwiq/Qwiq.Core/Qwiq.Core.csproj
@@ -34,6 +34,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=2.16.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.16.204221202\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
       <Private>True</Private>

--- a/Qwiq/Qwiq.Core/packages.config
+++ b/Qwiq/Qwiq.Core/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.16.204221202" targetFramework="net45" />


### PR DESCRIPTION
```
- The previous implementation used RealProxy, which was not
```

supported in a powershell environment. Additionally it made debugging
difficult.
    - Castle's implementation of a dynamic proxy fixes these issues
