### PR TITLE
Update MockIdentityManagementService and MockIdentityDescriptor

### DIFF
--- a/Qwiq/Qwiq.Mocks/MockIdentityDescriptor.cs
+++ b/Qwiq/Qwiq.Mocks/MockIdentityDescriptor.cs
@@ -2,27 +2,31 @@
 {
     public class MockIdentityDescriptor : IIdentityDescriptor
     {
+        public const string TenantId = "CD4C5751-F4E6-41D5-A4C9-EFFD66BC8E9C";
+
+        public const string Domain = "domain.local";
+
         /// <summary>
         /// Creates a ClaimsIdentity for the given <paramref name="alias"/>.
         /// </summary>
         /// <param name="alias">The sAMAccountName of the user (e.g. ftotten)</param>
         public MockIdentityDescriptor(string alias)
-            : this("Microsoft.IdentityModel.Claims.ClaimsIdentity", $"CD4C5751-F4E6-41D5-A4C9-EFFD66BC8E9C\\{alias}@domain.local")
+            : this("Microsoft.IdentityModel.Claims.ClaimsIdentity", $"{TenantId}\\{alias}@{Domain}")
         {
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="identityType"></param>
         /// <param name="identifier"></param>
         /// <example>
         /// User:
         /// "Microsoft.IdentityModel.Claims.ClaimsIdentity", "2fa3a376-370f-4226-9fbb-d778e4b5bf74\\ftotten@fabrikam.com"
-        /// 
+        ///
         /// Service:
         /// "Microsoft.TeamFoundation.ServiceIdentity", "d9454f90-6587-4699-9357-3e83e331580a:Build:f2200ea9-52cf-4343-8c80-af2cfa409984"
-        /// 
+        ///
         /// TFS Identity:
         /// "Microsoft.TeamFoundation.Identity", "S-1-9-1234567890-1234567890-123456789-1234567890-1234567890-1-1234567890-1234567890-1234567890-1234567890"
         /// </example>

--- a/Qwiq/Qwiq.Mocks/Properties/AssemblyInfo.cs
+++ b/Qwiq/Qwiq.Mocks/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1.0")]
-[assembly: AssemblyFileVersion("1.0.1.0")]
-[assembly: AssemblyInformationalVersion("1.0.1")]
+[assembly: AssemblyVersion("1.0.2.0")]
+[assembly: AssemblyFileVersion("1.0.2.0")]
+[assembly: AssemblyInformationalVersion("1.0.2")]


### PR DESCRIPTION
- ReadIdentities(IIdentityDescriptor) correctly gives 1:1 mapping with input
- ReadIdentities(IdentitySearchFactor) gives correct 1:1 mapping with input
- ReadIdentities(IdentitySearchFactor) gives correct output for DisplayName / AccountName
- Expose mock values for IdentityDescriptor

Code Review: @pelavall 
