### PR TITLE
Update Fragments to take ICollection not IEnumerable

### DIFF
--- a/Qwiq/Qwiq.Linq/Fragments/ConstantListFragment.cs
+++ b/Qwiq/Qwiq.Linq/Fragments/ConstantListFragment.cs
@@ -6,7 +6,7 @@ namespace Microsoft.IE.Qwiq.Linq.Fragments
     internal class ConstantListFragment : ListFragment
     {
         public ConstantListFragment(IEnumerable<string> strings)
-            : base(strings.Select(s => new ConstantFragment(s)))
+            : base(strings.Select(s => new ConstantFragment(s)).ToArray())
         {
         }
     }

--- a/Qwiq/Qwiq.Linq/Fragments/ListFragment.cs
+++ b/Qwiq/Qwiq.Linq/Fragments/ListFragment.cs
@@ -6,16 +6,16 @@ namespace Microsoft.IE.Qwiq.Linq.Fragments
 {
     internal class ListFragment : IFragment
     {
-        private readonly IEnumerable<IFragment> _fragments;
+        private readonly ICollection<IFragment> _fragments;
 
-        public ListFragment(IEnumerable<IFragment> fragments)
+        public ListFragment(ICollection<IFragment> fragments)
         {
             _fragments = fragments;
         }
 
         public string Get(Type queryType)
         {
-            return "(" + String.Join(", ", _fragments.Select(s => s.Get(queryType))) + ")";
+            return "(" + string.Join(", ", _fragments.Select(s => s.Get(queryType))) + ")";
         }
 
         public bool IsValid()

--- a/Qwiq/Qwiq.Linq/Fragments/NumberListFragment.cs
+++ b/Qwiq/Qwiq.Linq/Fragments/NumberListFragment.cs
@@ -6,7 +6,7 @@ namespace Microsoft.IE.Qwiq.Linq.Fragments
     internal class NumberListFragment : ListFragment
     {
         public NumberListFragment(IEnumerable<int> numbers)
-            : base(numbers.Select(number => new StringFragment(number.ToString())))
+            : base(numbers.Select(number => new StringFragment(number.ToString())).ToArray())
         {
         }
     }

--- a/Qwiq/Qwiq.Linq/Fragments/SelectFragment.cs
+++ b/Qwiq/Qwiq.Linq/Fragments/SelectFragment.cs
@@ -5,9 +5,9 @@ namespace Microsoft.IE.Qwiq.Linq.Fragments
 {
     internal class SelectFragment : IFragment
     {
-        private readonly IEnumerable<string> _fields;
+        private readonly ICollection<string> _fields;
 
-        public SelectFragment(IEnumerable<string> fields)
+        public SelectFragment(ICollection<string> fields)
         {
             _fields = fields;
         }

--- a/Qwiq/Qwiq.Linq/Fragments/TypeRestrictionFragment.cs
+++ b/Qwiq/Qwiq.Linq/Fragments/TypeRestrictionFragment.cs
@@ -6,9 +6,9 @@ namespace Microsoft.IE.Qwiq.Linq.Fragments
 {
     internal class TypeRestrictionFragment : IFragment
     {
-        private readonly IEnumerable<string> _workItemTypes;
+        private readonly ICollection<string> _workItemTypes;
 
-        public TypeRestrictionFragment(IEnumerable<string> workItemTypes)
+        public TypeRestrictionFragment(ICollection<string> workItemTypes)
         {
             _workItemTypes = workItemTypes;
         }

--- a/Qwiq/Qwiq.Linq/Properties/AssemblyInfo.cs
+++ b/Qwiq/Qwiq.Linq/Properties/AssemblyInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.0.1.0")]
-[assembly: AssemblyFileVersion("3.0.1.0")]
-[assembly: AssemblyInformationalVersion("3.0.1")]
+[assembly: AssemblyVersion("3.0.2.0")]
+[assembly: AssemblyFileVersion("3.0.2.0")]
+[assembly: AssemblyInformationalVersion("3.0.2")]

--- a/Qwiq/Qwiq.Linq/WiqlTranslator.cs
+++ b/Qwiq/Qwiq.Linq/WiqlTranslator.cs
@@ -39,9 +39,9 @@ namespace Microsoft.IE.Qwiq.Linq
             var query = translator.Query;
 
             query.UnderlyingQueryType = query.UnderlyingQueryType ?? TypeSystem.GetElementType(expression.Type);
-            query.Select = new SelectFragment(FieldMapper.GetFieldNames(query.UnderlyingQueryType));
+            query.Select = new SelectFragment(FieldMapper.GetFieldNames(query.UnderlyingQueryType).ToList());
 
-            var workItemTypeRestriction = FieldMapper.GetWorkItemType(query.UnderlyingQueryType);
+            var workItemTypeRestriction = FieldMapper.GetWorkItemType(query.UnderlyingQueryType).ToList();
             if (workItemTypeRestriction.Any())
             {
                 query.WhereClauses.Enqueue(new TypeRestrictionFragment(workItemTypeRestriction));


### PR DESCRIPTION
```
-Replacing IEnumerable with ICollection will ensure when calling
evaluations down the line will not cause re-evaluation of the
data source
```
