### PR TITLE
Treat .ToString() as a cast in Query Provider

### DIFF
--- a/src/Qwiq.Linq/Visitors/QueryRewriter.cs
+++ b/src/Qwiq.Linq/Visitors/QueryRewriter.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Qwiq.Linq.Visitors
 
                 if (projection == null)
                 {
-                    throw new NotSupportedException(String.Format("Performing a select without a lambda is not supported"));
+                    throw new NotSupportedException("Performing a select without a lambda is not supported");
                 }
 
                 return new SelectExpression(node.Type, select, projection);
@@ -63,7 +63,7 @@ namespace Microsoft.Qwiq.Linq.Visitors
                 return new OrderExpression(node.Type, source, orderSelector, OrderOptions.Descending);
             }
 
-            if (node.Method.DeclaringType == typeof(String) && node.Method.Name == "StartsWith")
+            if (node.Method.DeclaringType == typeof(string) && node.Method.Name == "StartsWith")
             {
                 var subject = Visit(node.Object);
                 var target = Visit(node.Arguments[0]);
@@ -81,7 +81,7 @@ namespace Microsoft.Qwiq.Linq.Visitors
             }
 
             // This is a contains used to do substring matching on a value, such as: bug => bug.Status.Contains("Approved")
-            if (node.Method.DeclaringType == typeof(String) && node.Method.Name == "Contains")
+            if (node.Method.DeclaringType == typeof(string) && node.Method.Name == "Contains")
             {
                 var subject = Visit(node.Object);
                 var target = Visit(node.Arguments[0]);
@@ -99,11 +99,11 @@ namespace Microsoft.Qwiq.Linq.Visitors
 
             if (node.Method.Name == "ToUpper" || node.Method.Name == "ToUpperInvariant" || node.Method.Name == "ToLower" || node.Method.Name == "ToLowerInvariant")
             {
-                throw new NotSupportedException(String.Format("The method {0} is not supported. Queries are case insensitive, so string comparisons should use the regular operators ( ==, > <=, etc.)", node.Method.Name));
+                throw new NotSupportedException($"The method {node.Method.Name} is not supported. Queries are case insensitive, so string comparisons should use the regular operators ( ==, > <=, etc.)");
             }
 
             // Unknown method call
-            throw new NotSupportedException(String.Format("The method '{0}' is not supported", node.Method.Name));
+            throw new NotSupportedException($"The method '{node.Method.Name}' is not supported");
         }
     }
 }

--- a/src/Qwiq.Linq/Visitors/QueryRewriter.cs
+++ b/src/Qwiq.Linq/Visitors/QueryRewriter.cs
@@ -102,6 +102,11 @@ namespace Microsoft.Qwiq.Linq.Visitors
                 throw new NotSupportedException($"The method {node.Method.Name} is not supported. Queries are case insensitive, so string comparisons should use the regular operators ( ==, > <=, etc.)");
             }
 
+            if (node.Method.Name == "ToString")
+            {
+                return Expression.TypeAs(Visit(node.Object), typeof(string));
+            }
+
             // Unknown method call
             throw new NotSupportedException($"The method '{node.Method.Name}' is not supported");
         }

--- a/test/Qwiq.Linq.Tests/QueryBuilderTests.cs
+++ b/test/Qwiq.Linq.Tests/QueryBuilderTests.cs
@@ -466,5 +466,23 @@ namespace Microsoft.Qwiq.Linq.Tests
             Actual.ShouldEqual(Expected);
         }
     }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
+    public class when_a_query_has_a_where_clause_with_a_ToString_in_it : GenericQueryBuilderTestsBase<MockModel>
+    {
+        public override void When()
+        {
+            base.When();
+            Expected = "SELECT " + string.Join(", ", FieldNames) + " FROM WorkItems WHERE (([StringField] = 'SomeValue') AND ([Work Item Type] = 'MockWorkItem'))";
+            Actual = Query.Where(item => item.StringField.ToString() == "SomeValue").ToString();
+        }
+
+        [TestMethod]
+        public void the_ToString_call_is_ignored()
+        {
+            Actual.ShouldEqual(Expected);
+        }
+    }
 }
 


### PR DESCRIPTION
`.ToString()` in a WIQL query has no effect, so rather than throwing a `NotSupportedException`, simply treat it as a cast and continue. Added a unit test to verify correct translation.

Scenario: Consider a work item type that has a mapped field of type `Object`. When querying on that field in LINQ (e.g. `.Where(item => item.ObjectField == "SomeValue")`) ReSharper will emit a warning as this
is a reference equality check (since `ObjectField` is of type `Object`) and would usually be a bug. The "correction" suggested is to change the expression to `item.ObjectField.ToString() == "SomeValue"`.

Since we're translating to WIQL and WIQL will never do reference equality anyways, this is safe and allows consumers to write clean code.