### PR TITLE
Support LINQ directly against IWorkItem

### DIFF
--- a/src/Qwiq.Linq/FieldMapper.cs
+++ b/src/Qwiq.Linq/FieldMapper.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Qwiq.Linq
                 type.GetProperties()
                     .SelectMany(property => property.GetCustomAttributes(typeof(FieldDefinitionAttribute), true))
                     .Cast<FieldDefinitionAttribute>();
-            var fieldNames = customAttributes.Select(attrib => "[" + attrib.FieldName + "]");
+            var fieldNames = customAttributes.Select(attrib => attrib.FieldName);
             return fieldNames.OrderBy(name => name);
             // Order alphabetically so string comparisons work and we don't needlessly permute our queries
         }
@@ -36,7 +36,7 @@ namespace Microsoft.Qwiq.Linq
                         + " Either map the '{0}' property or remove it from the query.", propertyName), nameof(propertyName));
             }
 
-            var fieldName = "[" + customAttribute.FieldName + "]";
+            var fieldName = customAttribute.FieldName;
             return fieldName;
         }
 

--- a/src/Qwiq.Linq/Fragments/MemberFragment.cs
+++ b/src/Qwiq.Linq/Fragments/MemberFragment.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Qwiq.Linq.Fragments
 
         public string Get(Type queryType)
         {
-            return _fieldMapper.GetFieldName(queryType, ParameterName);
+            return "[" + _fieldMapper.GetFieldName(queryType, ParameterName) + "]";
         }
 
         public bool IsValid()

--- a/src/Qwiq.Linq/Qwiq.Linq.csproj
+++ b/src/Qwiq.Linq/Qwiq.Linq.csproj
@@ -252,6 +252,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Query.cs" />
     <Compile Include="QueryExtensions.cs" />
+    <Compile Include="SimpleFieldMapper.cs" />
+    <Compile Include="SimpleWorkItemMapper.cs" />
     <Compile Include="TeamFoundationServerWorkItemQueryProvider.cs" />
     <Compile Include="TranslatedQuery.cs" />
     <Compile Include="TypeSystem.cs" />

--- a/src/Qwiq.Linq/Qwiq.Linq.csproj
+++ b/src/Qwiq.Linq/Qwiq.Linq.csproj
@@ -262,6 +262,7 @@
     <Compile Include="Visitors\WiqlQueryBuilder.cs" />
     <Compile Include="WiqlExpressions\AsOfExpression.cs" />
     <Compile Include="WiqlExpressions\ContainsExpression.cs" />
+    <Compile Include="WiqlExpressions\IndexerExpression.cs" />
     <Compile Include="WiqlExpressions\InExpression.cs" />
     <Compile Include="WiqlExpressions\OrderExpression.cs" />
     <Compile Include="WiqlExpressions\OrderOptions.cs" />

--- a/src/Qwiq.Linq/SimpleFieldMapper.cs
+++ b/src/Qwiq.Linq/SimpleFieldMapper.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Qwiq.Linq
+{
+    public class SimpleFieldMapper : IFieldMapper
+    {
+        private static readonly Dictionary<string, string> Mappings = new Dictionary<string, string>
+        {
+            {"AreaPath", "Area Path"},
+            {"AssignedTo", "Assigned To"},
+            {"ChangedBy", "Changed By"},
+            {"ChangedDate", "Changed Date"},
+            {"CreatedBy", "Created By"},
+            {"CreatedDate", "Created Date"},
+            {"IterationPath", "Iteration Path"},
+            {"RevisedDate", "Revised Date"}
+        };
+
+        private static readonly IEnumerable<string> FieldNames = new[] {"*"};
+
+        public IEnumerable<string> GetWorkItemType(Type type)
+        {
+            return Enumerable.Empty<string>();
+        }
+
+        public IEnumerable<string> GetFieldNames(Type type)
+        {
+            return FieldNames;
+        }
+
+        public string GetFieldName(Type type, string propertyName)
+        {
+            string name;
+            return Mappings.TryGetValue(propertyName, out name) ? name : propertyName;
+        }
+    }
+}

--- a/src/Qwiq.Linq/SimpleWorkItemMapper.cs
+++ b/src/Qwiq.Linq/SimpleWorkItemMapper.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Qwiq.Mapper;
+
+namespace Microsoft.Qwiq.Linq
+{
+    public class SimpleWorkItemMapper : IWorkItemMapper
+    {
+        public IEnumerable<T> Create<T>(IEnumerable<IWorkItem> collection) where T : IIdentifiable, new()
+        {
+            return collection.OfType<T>();
+        }
+
+        public IEnumerable<IIdentifiable> Create(Type type, IEnumerable<IWorkItem> collection)
+        {
+            return collection.OfType<IIdentifiable>();
+        }
+
+        public T Default<T>() where T : new()
+        {
+            return new T();
+        }
+
+        public IEnumerable<IWorkItemMapperStrategy> MapperStrategies { get; }
+    }
+}

--- a/src/Qwiq.Linq/TeamFoundationServerWorkItemQueryProvider.cs
+++ b/src/Qwiq.Linq/TeamFoundationServerWorkItemQueryProvider.cs
@@ -11,6 +11,11 @@ namespace Microsoft.Qwiq.Linq
     public class TeamFoundationServerWorkItemQueryProvider : IQueryProvider
     {
         public TeamFoundationServerWorkItemQueryProvider(IWorkItemStore workItemStore,
+            IWiqlQueryBuilder queryBuilder) : this(workItemStore, queryBuilder, new SimpleWorkItemMapper())
+        {
+        }
+
+        public TeamFoundationServerWorkItemQueryProvider(IWorkItemStore workItemStore,
             IWiqlQueryBuilder queryBuilder, IWorkItemMapper workItemMapper)
         {
             WorkItemStore = workItemStore;

--- a/src/Qwiq.Linq/Visitors/QueryRewriter.cs
+++ b/src/Qwiq.Linq/Visitors/QueryRewriter.cs
@@ -107,6 +107,13 @@ namespace Microsoft.Qwiq.Linq.Visitors
                 return Expression.TypeAs(Visit(node.Object), typeof(string));
             }
 
+            if (node.Method.Name == "get_Item")
+            {
+                var subject = node.Object;
+                var name = Visit(node.Arguments[0]);
+                return new IndexerExpression(node.Type, subject, name);
+            }
+
             // Unknown method call
             throw new NotSupportedException($"The method '{node.Method.Name}' is not supported");
         }

--- a/src/Qwiq.Linq/WiqlExpressions/AsOfExpression.cs
+++ b/src/Qwiq.Linq/WiqlExpressions/AsOfExpression.cs
@@ -5,29 +5,15 @@ namespace Microsoft.Qwiq.Linq.WiqlExpressions
 {
     public class AsOfExpression : Expression
     {
-        private readonly Type _type;
-
         internal AsOfExpression(Type type, DateTime asOfDateTime)
         {
-            _type = type;
-
+            Type = type;
             AsOfDateTime = asOfDateTime;
         }
 
-        public override ExpressionType NodeType
-        {
-            get
-            {
-                return (ExpressionType)WiqlExpressionType.AsOf;
-            }
-        }
-        public override Type Type
-        {
-            get
-            {
-                return _type;
-            }
-        }
+        public override ExpressionType NodeType => (ExpressionType)WiqlExpressionType.AsOf;
+
+        public override Type Type { get; }
 
         internal DateTime AsOfDateTime { get; private set; }
     }

--- a/src/Qwiq.Linq/WiqlExpressions/ContainsExpression.cs
+++ b/src/Qwiq.Linq/WiqlExpressions/ContainsExpression.cs
@@ -5,30 +5,16 @@ namespace Microsoft.Qwiq.Linq.WiqlExpressions
 {
     public class ContainsExpression : Expression
     {
-        private readonly Type _type;
-
         internal ContainsExpression(Type type, Expression subject, Expression target)
         {
-            _type = type;
-
+            Type = type;
             Subject = subject;
             Target = target;
         }
 
-        public override ExpressionType NodeType
-        {
-            get
-            {
-                return (ExpressionType)WiqlExpressionType.Contains;
-            }
-        }
-        public override Type Type
-        {
-            get
-            {
-                return _type;
-            }
-        }
+        public override ExpressionType NodeType => (ExpressionType)WiqlExpressionType.Contains;
+
+        public override Type Type { get; }
 
         internal Expression Subject { get; private set; }
         internal Expression Target { get; private set; }

--- a/src/Qwiq.Linq/WiqlExpressions/InExpression.cs
+++ b/src/Qwiq.Linq/WiqlExpressions/InExpression.cs
@@ -5,30 +5,16 @@ namespace Microsoft.Qwiq.Linq.WiqlExpressions
 {
     public class InExpression : Expression
     {
-        private readonly Type _type;
-
         internal InExpression(Type type, Expression subject, Expression target)
         {
-            _type = type;
-
+            Type = type;
             Subject = subject;
             Target = target;
         }
 
-        public override ExpressionType NodeType
-        {
-            get
-            {
-                return (ExpressionType)WiqlExpressionType.In;
-            }
-        }
-        public override Type Type
-        {
-            get
-            {
-                return _type;
-            }
-        }
+        public override ExpressionType NodeType => (ExpressionType)WiqlExpressionType.In;
+
+        public override Type Type { get; }
 
         internal Expression Subject { get; private set; }
         internal Expression Target { get; private set; }

--- a/src/Qwiq.Linq/WiqlExpressions/IndexerExpression.cs
+++ b/src/Qwiq.Linq/WiqlExpressions/IndexerExpression.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Linq.Expressions;
+
+namespace Microsoft.Qwiq.Linq.WiqlExpressions
+{
+    public class IndexerExpression : Expression
+    {
+        internal IndexerExpression(Type type, Expression subject, Expression target)
+        {
+            Type = type;
+            Subject = subject;
+            Target = target as ConstantExpression;
+        }
+
+        public override ExpressionType NodeType => (ExpressionType) WiqlExpressionType.Indexer;
+        public override Type Type { get; }
+
+        internal Expression Subject { get; private set;}
+        internal ConstantExpression Target { get; private set; }
+    }
+}

--- a/src/Qwiq.Linq/WiqlExpressions/OrderExpression.cs
+++ b/src/Qwiq.Linq/WiqlExpressions/OrderExpression.cs
@@ -5,32 +5,17 @@ namespace Microsoft.Qwiq.Linq.WiqlExpressions
 {
     public class OrderExpression : Expression
     {
-        private readonly Type _type;
-
         internal OrderExpression(Type type, Expression source, Expression orderSelector, OrderOptions options)
         {
-            _type = type;
-
+            Type = type;
             Source = source;
             OrderSelector = orderSelector;
             Options = options;
         }
 
-        public override ExpressionType NodeType
-        {
-            get
-            {
-                return (ExpressionType)WiqlExpressionType.Order;
-            }
-        }
+        public override ExpressionType NodeType => (ExpressionType)WiqlExpressionType.Order;
 
-        public override Type Type
-        {
-            get
-            {
-                return _type;
-            }
-        }
+        public override Type Type { get; }
 
         internal Expression Source { get; private set; }
 

--- a/src/Qwiq.Linq/WiqlExpressions/SelectExpression.cs
+++ b/src/Qwiq.Linq/WiqlExpressions/SelectExpression.cs
@@ -5,31 +5,20 @@ namespace Microsoft.Qwiq.Linq.WiqlExpressions
 {
     public class SelectExpression : Expression
     {
-        private readonly Type _type;
-
         public Expression Select { get; private set; }
 
         public LambdaExpression Projection { get; private set; }
 
         internal SelectExpression(Type type, Expression select, LambdaExpression projection)
         {
-            _type = type;
+            Type = type;
             Select = select;
             Projection = projection;
         }
 
-        public override Type Type
-        {
-            get { return _type; }
-        }
+        public override Type Type { get; }
 
-        public override ExpressionType NodeType
-        {
-            get
-            {
-                return (ExpressionType)WiqlExpressionType.Select;
-            }
-        }
+        public override ExpressionType NodeType => (ExpressionType)WiqlExpressionType.Select;
     }
 }
 

--- a/src/Qwiq.Linq/WiqlExpressions/UnderExpression.cs
+++ b/src/Qwiq.Linq/WiqlExpressions/UnderExpression.cs
@@ -5,30 +5,16 @@ namespace Microsoft.Qwiq.Linq.WiqlExpressions
 {
     public class UnderExpression : Expression
     {
-        private readonly Type _type;
-
         internal UnderExpression(Type type, Expression subject, Expression target)
         {
-            _type = type;
-
+            Type = type;
             Subject = subject;
             Target = target;
         }
 
-        public override ExpressionType NodeType
-        {
-            get
-            {
-                return (ExpressionType)WiqlExpressionType.Under;
-            }
-        }
-        public override Type Type
-        {
-            get
-            {
-                return _type;
-            }
-        }
+        public override ExpressionType NodeType => (ExpressionType)WiqlExpressionType.Under;
+
+        public override Type Type { get; }
 
         internal Expression Subject { get; private set; }
         internal Expression Target { get; private set; }

--- a/src/Qwiq.Linq/WiqlExpressions/WhereExpression.cs
+++ b/src/Qwiq.Linq/WiqlExpressions/WhereExpression.cs
@@ -5,31 +5,16 @@ namespace Microsoft.Qwiq.Linq.WiqlExpressions
 {
     public class WhereExpression : Expression
     {
-        private readonly Type _type;
-
         internal WhereExpression(Type type, Expression source, Expression filter)
         {
-            _type = type;
-
+            Type = type;
             Source = source;
             Filter = filter;
         }
 
-        public override ExpressionType NodeType
-        {
-            get
-            {
-                return (ExpressionType)WiqlExpressionType.Where;
-            }
-        }
+        public override ExpressionType NodeType => (ExpressionType)WiqlExpressionType.Where;
 
-        public override Type Type
-        {
-            get
-            {
-                return _type;
-            }
-        }
+        public override Type Type { get; }
 
         internal Expression Source { get; private set; }
 

--- a/src/Qwiq.Linq/WiqlExpressions/WiqlExpressionType.cs
+++ b/src/Qwiq.Linq/WiqlExpressions/WiqlExpressionType.cs
@@ -8,7 +8,8 @@ namespace Microsoft.Qwiq.Linq.WiqlExpressions
         Order,
         AsOf,
         Contains,
-        Select
+        Select,
+        Indexer
     }
 }
 

--- a/src/Qwiq.Linq/WiqlTranslator.cs
+++ b/src/Qwiq.Linq/WiqlTranslator.cs
@@ -21,6 +21,10 @@ namespace Microsoft.Qwiq.Linq
     {
         protected readonly IFieldMapper FieldMapper;
 
+        public WiqlTranslator() : this(new SimpleFieldMapper())
+        {
+        }
+
         public WiqlTranslator(IFieldMapper fieldMapper)
         {
             FieldMapper = fieldMapper;

--- a/src/Qwiq.Linq/WiqlTranslator.cs
+++ b/src/Qwiq.Linq/WiqlTranslator.cs
@@ -90,6 +90,8 @@ namespace Microsoft.Qwiq.Linq
                         return VisitAsOf((AsOfExpression)expression);
                     case WiqlExpressionType.Contains:
                         return VisitContains((ContainsExpression)expression);
+                    case WiqlExpressionType.Indexer:
+                        return VisitIndexer((IndexerExpression) expression);
                     default:
                         return base.Visit(expression);
                 }
@@ -321,6 +323,13 @@ namespace Microsoft.Qwiq.Linq
                 }
 
                 throw new NotSupportedException(string.Format("The member '{0}' is not supported", node.Member.Name));
+            }
+
+            protected Expression VisitIndexer(IndexerExpression node)
+            {
+                _expressionInProgress.Enqueue(new MemberFragment(_fieldMapper, node.Target.Value.ToString()));
+
+                return node;
             }
         }
     }

--- a/src/Qwiq.Linq/WiqlTranslator.cs
+++ b/src/Qwiq.Linq/WiqlTranslator.cs
@@ -207,8 +207,7 @@ namespace Microsoft.Qwiq.Linq
                         Visit(node.Operand);
                         break;
                     default:
-                        throw new NotSupportedException(string.Format("The unary operator '{0}' is not supported",
-                            node.NodeType));
+                        throw new NotSupportedException($"The unary operator '{node.NodeType}' is not supported");
                 }
 
                 return node;
@@ -248,8 +247,7 @@ namespace Microsoft.Qwiq.Linq
                         _expressionInProgress.Enqueue(new StringFragment(" >= "));
                         break;
                     default:
-                        throw new NotSupportedException(string.Format("The binary operator '{0}' is not supported",
-                            node.NodeType));
+                        throw new NotSupportedException($"The binary operator '{node.NodeType}' is not supported");
                 }
 
                 Visit(node.Right);
@@ -299,8 +297,7 @@ namespace Microsoft.Qwiq.Linq
                             _expressionInProgress.Enqueue(new StringFragment(node.Value.ToString()));
                             break;
                         default:
-                            throw new NotSupportedException(string.Format("The constant for '{0}' is not supported",
-                                node.Value));
+                            throw new NotSupportedException($"The constant for '{node.Value}' is not supported");
                     }
                 }
 
@@ -322,7 +319,7 @@ namespace Microsoft.Qwiq.Linq
                     return Visit(node.Expression);
                 }
 
-                throw new NotSupportedException(string.Format("The member '{0}' is not supported", node.Member.Name));
+                throw new NotSupportedException($"The member '{node.Member.Name}' is not supported");
             }
 
             protected Expression VisitIndexer(IndexerExpression node)

--- a/test/Qwiq.Linq.Tests/QueryBuilderTests.cs
+++ b/test/Qwiq.Linq.Tests/QueryBuilderTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Should;
 using Microsoft.Qwiq.Linq.Tests.Mocks;
+using Microsoft.Qwiq.Linq.Visitors;
+using Microsoft.Qwiq.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Qwiq.Linq.Tests
@@ -476,6 +478,29 @@ namespace Microsoft.Qwiq.Linq.Tests
 
         [TestMethod]
         public void the_ToString_call_is_ignored()
+        {
+            Actual.ShouldEqual(Expected);
+        }
+    }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
+    public class when_a_query_has_a_where_clause_with_a_type_that_uses_an_indexer : GenericQueryBuilderTestsBase<IWorkItem>
+    {
+        public override void When()
+        {
+            base.When();
+
+            Builder = new WiqlQueryBuilder(new WiqlTranslator(), new PartialEvaluator(), new QueryRewriter());
+            QueryProvider = new TeamFoundationServerWorkItemQueryProvider(new MockWorkItemStore(), Builder);
+            Query = new Query<IWorkItem>(QueryProvider, Builder);
+
+            Expected = "SELECT * FROM WorkItems WHERE (([Some Property] = 'Some Value'))";
+            Actual = Query.Where(item => item["Some Property"].ToString() == "Some Value").ToString();
+        }
+
+        [TestMethod]
+        public void the_index_name_is_used_as_a_field_name()
         {
             Actual.ShouldEqual(Expected);
         }

--- a/test/Qwiq.Linq.Tests/QueryBuilderTests.cs
+++ b/test/Qwiq.Linq.Tests/QueryBuilderTests.cs
@@ -28,13 +28,9 @@ namespace Microsoft.Qwiq.Linq.Tests
         }
     }
 
-    public abstract class QueryBuilderTestsBase : GenericQueryBuilderTestsBase<MockModel>
-    {
-    }
-
     [TestClass]
     // ReSharper disable once InconsistentNaming
-    public class when_a_query_has_a_where_clause_with_an_and_expression : QueryBuilderTestsBase
+    public class when_a_query_has_a_where_clause_with_an_and_expression : GenericQueryBuilderTestsBase<MockModel>
     {
         private DateTime _date;
 
@@ -60,7 +56,7 @@ namespace Microsoft.Qwiq.Linq.Tests
 
     [TestClass]
     // ReSharper disable once InconsistentNaming
-    public class when_a_query_has_an_asof_clause : QueryBuilderTestsBase
+    public class when_a_query_has_an_asof_clause : GenericQueryBuilderTestsBase<MockModel>
     {
         private DateTime _date;
 
@@ -87,7 +83,7 @@ namespace Microsoft.Qwiq.Linq.Tests
 
     [TestClass]
     // ReSharper disable once InconsistentNaming
-    public class when_a_query_has_chained_where_clauses : QueryBuilderTestsBase
+    public class when_a_query_has_chained_where_clauses : GenericQueryBuilderTestsBase<MockModel>
     {
         private DateTime _date;
 
@@ -117,7 +113,7 @@ namespace Microsoft.Qwiq.Linq.Tests
 
     [TestClass]
     // ReSharper disable once InconsistentNaming
-    public class when_a_query_has_a_where_clause_with_an_or_expression : QueryBuilderTestsBase
+    public class when_a_query_has_a_where_clause_with_an_or_expression : GenericQueryBuilderTestsBase<MockModel>
     {
         public override void When()
         {
@@ -135,7 +131,7 @@ namespace Microsoft.Qwiq.Linq.Tests
 
     [TestClass]
     // ReSharper disable once InconsistentNaming
-    public class when_a_query_has_a_field_that_should_be_in_a_list_of_values : QueryBuilderTestsBase
+    public class when_a_query_has_a_field_that_should_be_in_a_list_of_values : GenericQueryBuilderTestsBase<MockModel>
     {
         private string[] _values;
         public override void Given()
@@ -160,7 +156,7 @@ namespace Microsoft.Qwiq.Linq.Tests
 
     [TestClass]
     // ReSharper disable once InconsistentNaming
-    public class when_a_query_is_on_a_field_that_is_nullable : QueryBuilderTestsBase
+    public class when_a_query_is_on_a_field_that_is_nullable : GenericQueryBuilderTestsBase<MockModel>
     {
         public override void When()
         {
@@ -178,7 +174,7 @@ namespace Microsoft.Qwiq.Linq.Tests
 
     [TestClass]
     // ReSharper disable once InconsistentNaming
-    public class when_a_query_has_a_field_compared_with_null : QueryBuilderTestsBase
+    public class when_a_query_has_a_field_compared_with_null : GenericQueryBuilderTestsBase<MockModel>
     {
         public override void When()
         {
@@ -196,7 +192,7 @@ namespace Microsoft.Qwiq.Linq.Tests
 
     [TestClass]
     // ReSharper disable once InconsistentNaming
-    public class when_a_query_has_a_field_comparison_of_greater_than : QueryBuilderTestsBase
+    public class when_a_query_has_a_field_comparison_of_greater_than : GenericQueryBuilderTestsBase<MockModel>
     {
         public override void When()
         {
@@ -214,7 +210,7 @@ namespace Microsoft.Qwiq.Linq.Tests
 
     [TestClass]
     // ReSharper disable once InconsistentNaming
-    public class when_a_query_uses_the_not_equals_operator : QueryBuilderTestsBase
+    public class when_a_query_uses_the_not_equals_operator : GenericQueryBuilderTestsBase<MockModel>
     {
         public override void When()
         {
@@ -232,7 +228,7 @@ namespace Microsoft.Qwiq.Linq.Tests
 
     [TestClass]
     // ReSharper disable once InconsistentNaming
-    public class when_a_where_clause_has_a_lazy_ienumerable_in_the_expression : QueryBuilderTestsBase
+    public class when_a_where_clause_has_a_lazy_ienumerable_in_the_expression : GenericQueryBuilderTestsBase<MockModel>
     {
         private readonly string[] _aliases = { "person1", "person2" };
         private IEnumerable<string> _filteredAliases;
@@ -260,7 +256,7 @@ namespace Microsoft.Qwiq.Linq.Tests
 
     [TestClass]
     // ReSharper disable once InconsistentNaming
-    public class when_a_constant_has_a_special_wiql_character : QueryBuilderTestsBase
+    public class when_a_constant_has_a_special_wiql_character : GenericQueryBuilderTestsBase<MockModel>
     {
         public override void When()
         {
@@ -279,7 +275,7 @@ namespace Microsoft.Qwiq.Linq.Tests
 
     [TestClass]
     // ReSharper disable once InconsistentNaming
-    public class when_an_ienumerable_contains_constants_with_special_wiql_characters : QueryBuilderTestsBase
+    public class when_an_ienumerable_contains_constants_with_special_wiql_characters : GenericQueryBuilderTestsBase<MockModel>
     {
         private readonly string[] _values = { "Robert O'Sullivan", "Robert O'Laney" };
 
@@ -299,7 +295,7 @@ namespace Microsoft.Qwiq.Linq.Tests
 
     [TestClass]
     // ReSharper disable once InconsistentNaming
-    public class when_a_where_clause_filters_on_a_field_with_no_field_definition_attribute : QueryBuilderTestsBase
+    public class when_a_where_clause_filters_on_a_field_with_no_field_definition_attribute : GenericQueryBuilderTestsBase<MockModel>
     {
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
@@ -312,7 +308,7 @@ namespace Microsoft.Qwiq.Linq.Tests
 
     [TestClass]
     // ReSharper disable once InconsistentNaming
-    public class when_a_query_contains_an_OrderByDescending_and_ThenBy_clauses : QueryBuilderTestsBase
+    public class when_a_query_contains_an_OrderByDescending_and_ThenBy_clauses : GenericQueryBuilderTestsBase<MockModel>
     {
         public override void When()
         {
@@ -330,7 +326,7 @@ namespace Microsoft.Qwiq.Linq.Tests
 
     [TestClass]
     // ReSharper disable once InconsistentNaming
-    public class when_a_where_clause_contains_a_ToUpper_call_on_a_string : QueryBuilderTestsBase
+    public class when_a_where_clause_contains_a_ToUpper_call_on_a_string : GenericQueryBuilderTestsBase<MockModel>
     {
         [TestMethod]
         [ExpectedException(typeof(NotSupportedException))]
@@ -343,7 +339,7 @@ namespace Microsoft.Qwiq.Linq.Tests
 
     [TestClass]
     // ReSharper disable once InconsistentNaming
-    public class when_a_where_clause_uses_the_StartsWith_string_function : QueryBuilderTestsBase
+    public class when_a_where_clause_uses_the_StartsWith_string_function : GenericQueryBuilderTestsBase<MockModel>
     {
         public override void When()
         {
@@ -361,7 +357,7 @@ namespace Microsoft.Qwiq.Linq.Tests
 
     [TestClass]
     // ReSharper disable once InconsistentNaming
-    public class when_a_where_clause_uses_the_Contains_string_function : QueryBuilderTestsBase
+    public class when_a_where_clause_uses_the_Contains_string_function : GenericQueryBuilderTestsBase<MockModel>
     {
         public override void When()
         {
@@ -379,7 +375,7 @@ namespace Microsoft.Qwiq.Linq.Tests
 
     [TestClass]
     // ReSharper disable once InconsistentNaming
-    public class when_a_select_clause_is_used : QueryBuilderTestsBase
+    public class when_a_select_clause_is_used : GenericQueryBuilderTestsBase<MockModel>
     {
         public override void When()
         {
@@ -397,7 +393,7 @@ namespace Microsoft.Qwiq.Linq.Tests
 
     [TestClass]
     // ReSharper disable once InconsistentNaming
-    public class when_two_select_clauses_are_chained : QueryBuilderTestsBase
+    public class when_two_select_clauses_are_chained : GenericQueryBuilderTestsBase<MockModel>
     {
         public override void When()
         {
@@ -415,7 +411,7 @@ namespace Microsoft.Qwiq.Linq.Tests
 
     [TestClass]
     // ReSharper disable once InconsistentNaming
-    public class when_a_where_clause_is_chained_to_a_select_clause : QueryBuilderTestsBase
+    public class when_a_where_clause_is_chained_to_a_select_clause : GenericQueryBuilderTestsBase<MockModel>
     {
         public override void When()
         {


### PR DESCRIPTION
This is the first and non-breaking part of updating Qwiq.Linq to work directly against `IWorkItem`. A future PR will further simplify things but requires breaking changes. The process is:

1. Create "simple" versions of `IWorkItemMapper` and `IFieldMapper` that don't rely on the attribute and mapping system in Qwiq.Mapper
2. Make those simple versions the default implementation to simplify construction for consumers that aren't using Mapper models
3. Support the indexer (e.g. `item["MyProperty"]`) as a member access during Expression visitation.