### PR TITLE
Expose ApplyRules on IWorkItem

### DIFF
--- a/src/Qwiq.Core/IWorkItem.cs
+++ b/src/Qwiq.Core/IWorkItem.cs
@@ -212,5 +212,17 @@ namespace Microsoft.Qwiq
         /// An ArrayList of the fields in this work item that are not valid.
         /// </returns>
         IEnumerable<IField> Validate();
+
+        /// <summary>
+        /// Applies the server rules for validation and fix up to the work item.
+        /// </summary>
+        /// <param name="doNotUpdateChangedBy">
+        /// If true, will set ChangedBy to the user context of the <see cref="IWorkItemStore"/>.
+        /// If false, ChangedBy will not be modified.
+        /// </param>
+        /// <remarks>
+        /// Use ApplyRules(true) in the case where you want "transparent fix ups".
+        /// </remarks>
+        void ApplyRules(bool doNotUpdateChangedBy = false);
     }
 }

--- a/src/Qwiq.Core/Proxies/WorkItemProxy.cs
+++ b/src/Qwiq.Core/Proxies/WorkItemProxy.cs
@@ -416,6 +416,11 @@ namespace Microsoft.Qwiq.Proxies
                 throw new ServerRejectedChangesException(ex);
             }
         }
+
+        public void ApplyRules(bool doNotUpdateChangedBy = false)
+        {
+            _item.ApplyRules(doNotUpdateChangedBy);
+        }
     }
 }
 

--- a/test/Qwiq.Mocks/MockWorkItem.cs
+++ b/test/Qwiq.Mocks/MockWorkItem.cs
@@ -398,5 +398,9 @@ namespace Microsoft.Qwiq.Mocks
                 _properties.Add(field, new MockField(value, value) { Name = field });
             }
         }
+
+        public void ApplyRules(bool doNotUpdateChangedBy = false)
+        {
+        }
     }
 }


### PR DESCRIPTION
TFS has rules for validation of various fields, but are only detectable on a Save command(validation is run on the server not client). Apply Rules will run these rules on a workitem and also provide configured auto fix rules. These server side rules are not exposed through a call to Validate or IsValid and an error will only occur on a call to save. Exposing this api allows for work items to be put in a valid state before calling save, for workitems which may not be valid. 