### PR TITLE
Add support for null substitution

### DIFF
--- a/src/Qwiq.Mapper/Attributes/AttributeMapperStrategy.cs
+++ b/src/Qwiq.Mapper/Attributes/AttributeMapperStrategy.cs
@@ -84,41 +84,76 @@ namespace Microsoft.Qwiq.Mapper.Attributes
 #if DEBUG
             Trace.TraceInformation("{0}: Mapping {1}", GetType().Name, sourceWorkItem.Id);
 #endif
+            var properties = PropertiesOnWorkItemCache(
+                _inspector,
+                sourceWorkItem,
+                targetWorkItemType,
+                typeof(FieldDefinitionAttribute));
 
-            foreach (var property in PropertiesOnWorkItemCache(_inspector, sourceWorkItem, targetWorkItemType, typeof(FieldDefinitionAttribute)))
+            foreach (var property in properties)
             {
                 var a = PropertyInfoFieldCache(_inspector, property);
                 if (a == null) continue;
 
                 var fieldName = a.FieldName;
                 var convert = a.RequireConversion;
+                var nullSub = a.NullSubstitute;
+                var fieldValue = sourceWorkItem[fieldName];
 
                 try
                 {
                     if (convert)
                     {
-                        var value = _typeParser.Parse(property.PropertyType, sourceWorkItem[fieldName]);
-                        accessor[targetWorkItem, property.Name] = value;
+                        try
+                        {
+                            fieldValue = _typeParser.Parse(property.PropertyType, fieldValue, nullSub);
+                        }
+                        catch (Exception)
+                        {
+                            try
+                            {
+                                Trace.TraceWarning(
+                                    "Could not convert value of field '{0}' ({1}) to type {2}",
+                                    fieldName,
+                                    fieldValue.GetType().Name,
+                                    property.PropertyType.Name);
+                            }
+                            catch (Exception)
+                            {
+                                // Best effort
+                            }
+                        }
                     }
-                    else
+
+                    if (fieldValue == null && nullSub != null)
                     {
-                        accessor[targetWorkItem, property.Name] = sourceWorkItem[fieldName];
+                        fieldValue = nullSub;
+                    }
+
+                    accessor[targetWorkItem, property.Name] = fieldValue;
+
+                }
+                catch(NullReferenceException) when (fieldValue == null)
+                {
+                    // This is most likely the cause of the field being null and the target property type not accepting nulls
+                    // For example: mapping null to an int instead of int?
+
+                    try
+                    {
+                        Trace.TraceWarning(
+                            "Could not map field '{0}' from type '{1}' to type '{2}'. Target '{2}.{3}' does not accept null values.",
+                            fieldName,
+                            sourceWorkItem.Type.Name,
+                            targetWorkItemType.Name,
+                            $"{property.Name} ({property.PropertyType.FullName})");
+                    }
+                    catch (Exception)
+                    {
+                        // Best effort
                     }
                 }
                 catch (Exception e)
                 {
-                    try
-                    {
-                        Trace.TraceWarning(
-                            "Could not convert value of field '{0}' ({1}) to type {2}",
-                            fieldName,
-                            sourceWorkItem[fieldName].GetType().Name,
-                            property.PropertyType.Name);
-                    }
-                    catch (Exception)
-                    {
-                    }
-
                     try
                     {
                         Trace.TraceWarning(
@@ -130,6 +165,7 @@ namespace Microsoft.Qwiq.Mapper.Attributes
                     }
                     catch (Exception)
                     {
+                        // Best effort
                     }
                 }
             }

--- a/src/Qwiq.Mapper/Attributes/FieldDefinitionAttribute.cs
+++ b/src/Qwiq.Mapper/Attributes/FieldDefinitionAttribute.cs
@@ -5,21 +5,37 @@ namespace Microsoft.Qwiq.Mapper.Attributes
     [AttributeUsage(AttributeTargets.Property)]
     public class FieldDefinitionAttribute : Attribute
     {
+        /// <exception cref="ArgumentException">Value for <paramref name="name"/> cannot be null, empty, or only whitespace.</exception>
         public FieldDefinitionAttribute(string name)
-            : this(name, false)
+            : this(name, false, null)
         {
-
         }
 
+        /// <exception cref="ArgumentException">Value for <paramref name="name"/> cannot be null, empty, or only whitespace.</exception>
         public FieldDefinitionAttribute(string name, bool requireConversion)
+            : this(name, requireConversion, null)
         {
+        }
+
+        /// <exception cref="ArgumentException">Value for <paramref name="name"/> cannot be null, empty, or only whitespace.</exception>
+        public FieldDefinitionAttribute(string name, object nullSubstitute)
+            : this(name, false, nullSubstitute)
+        {
+        }
+
+        /// <exception cref="ArgumentException">Value for <paramref name="name"/> cannot be null, empty, or only whitespace.</exception>
+        public FieldDefinitionAttribute(string name, bool requireConversion, object nullSubstitute)
+        {
+            if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Value cannot be null or whitespace.", nameof(name));
             FieldName = name;
             RequireConversion = requireConversion;
+            NullSubstitute = nullSubstitute;
         }
 
         public string FieldName { get; }
 
+        public object NullSubstitute { get; }
+
         public bool RequireConversion { get; }
     }
 }
-

--- a/test/Qwiq.Identity.Tests/Mocks/IdentityMockType.cs
+++ b/test/Qwiq.Identity.Tests/Mocks/IdentityMockType.cs
@@ -36,10 +36,6 @@ namespace Qwiq.Identity.Tests.Mocks
         public string NotAnIdentity { get; set; }
 
         [IdentityField]
-        [FieldDefinition("")]
-        public string Empty { get; set; }
-
-        [IdentityField]
         [FieldDefinition(NonExistantField)]
         public string NonExistant { get; set; }
 

--- a/test/Qwiq.Mapper.Tests/WorkItemMapperTests.cs
+++ b/test/Qwiq.Mapper.Tests/WorkItemMapperTests.cs
@@ -82,6 +82,60 @@ namespace Microsoft.Qwiq.Mapper.Tests
     }
 
     [TestClass]
+    public class when_an_issue_is_mapped_with_a_field_containing_null_that_does_not_accept_null_and_has_a_null_substitute : WorkItemMapperContext<when_an_issue_is_mapped_with_a_field_containing_null_that_does_not_accept_null_and_has_a_null_substitute.MockModelWithMissingField>
+    {
+        public override void Given()
+        {
+            SourceWorkItems = new[] { new MockWorkItem("MissingFields", WorkItemBackingStore) };
+            WorkItemStore = new MockWorkItemStore(SourceWorkItems);
+            base.Given();
+        }
+
+        [TestMethod]
+        public void the_mapped_property_is_the_substituted_value()
+        {
+            Actual.DoesNotExist.ShouldEqual(-1);
+        }
+
+        [WorkItemType("MissingFields")]
+        public class MockModelWithMissingField : IIdentifiable
+        {
+            [FieldDefinition("Id")]
+            public virtual int Id { get; internal set; }
+
+            [FieldDefinition("NullableField", -1)]
+            public virtual int DoesNotExist { get; internal set; }
+        }
+    }
+
+    [TestClass]
+    public class when_an_issue_is_mapped_with_a_field_containing_null_that_does_not_accept_null_and_convert_and_has_a_null_substitute : WorkItemMapperContext<when_an_issue_is_mapped_with_a_field_containing_null_that_does_not_accept_null_and_convert_and_has_a_null_substitute.MockModelWithMissingField>
+    {
+        public override void Given()
+        {
+            SourceWorkItems = new[] { new MockWorkItem("Default", WorkItemBackingStore) };
+            WorkItemStore = new MockWorkItemStore(SourceWorkItems);
+            base.Given();
+        }
+
+        [TestMethod]
+        public void the_mapped_property_is_the_substituted_value()
+        {
+            Actual.DoesNotExist.ShouldEqual(-1);
+        }
+
+        [WorkItemType("Default")]
+        public class MockModelWithMissingField : IIdentifiable
+        {
+            [FieldDefinition("Id")]
+            public int Id { get; internal set; }
+
+            [FieldDefinition("NullableField", true, -1)]
+            public int DoesNotExist { get; internal set; }
+        }
+    }
+
+    [TestClass]
     // ReSharper disable once InconsistentNaming
     public class when_the_issue_factory_parses_an_issue_with_links : WorkItemMapperContext<MockModelWithLinks>
     {


### PR DESCRIPTION
Extend the `FieldDefinitionAttribute` to allow for a value to be substituted when the source field is empty.

For example, if a non-compulsory field "Priority" is Int32, and the target property type is also Int32, a default value of 0 is placed on the target.

This permits users to create properties with one of two types: Nullable<Int32> or Int32 with the substitute.

Resolves #122 