### PR TITLE
Expose credentials, performance / reliability fixes

### DIFF
--- a/src/Qwiq.Core/Credentials/CredentialsFactory.cs
+++ b/src/Qwiq.Core/Credentials/CredentialsFactory.cs
@@ -25,11 +25,14 @@ namespace Microsoft.Qwiq.Credentials
                     new Lazy<string>(() => accessToken));
         }
 
-        public static IEnumerable<TfsCredentials> CreateCredentials(Lazy<string> username, Lazy<string> password, Lazy<string> accessToken)
+        public static IEnumerable<TfsCredentials> CreateCredentials(
+            Lazy<string> username = null,
+            Lazy<string> password = null,
+            Lazy<string> accessToken = null)
         {
-            if (username == null) throw new ArgumentNullException(nameof(username));
-            if (password == null) throw new ArgumentNullException(nameof(password));
-            if (accessToken == null) throw new ArgumentNullException(nameof(accessToken));
+            if (username == null) username = new Lazy<string>(() => string.Empty);
+            if (password == null) password = new Lazy<string>(() => string.Empty);
+            if (accessToken == null) accessToken = new Lazy<string>(() => string.Empty);
 
             return CreateCredentialsImpl(username, password, accessToken)
                    .Select(c => new TfsCredentials(c));

--- a/src/Qwiq.Core/Credentials/TfsCredentials.cs
+++ b/src/Qwiq.Core/Credentials/TfsCredentials.cs
@@ -1,10 +1,13 @@
+using System.Diagnostics;
+
 using Microsoft.TeamFoundation.Client;
 
 namespace Microsoft.Qwiq.Credentials
 {
+    [DebuggerStepThrough]
     public sealed class TfsCredentials
     {
-        internal TfsCredentials(TfsClientCredentials credentials)
+        public TfsCredentials(TfsClientCredentials credentials)
         {
             Credentials = credentials;
         }
@@ -12,4 +15,3 @@ namespace Microsoft.Qwiq.Credentials
         internal TfsClientCredentials Credentials { get; private set; }
     }
 }
-

--- a/src/Qwiq.Core/ITfsTeamProjectCollection.cs
+++ b/src/Qwiq.Core/ITfsTeamProjectCollection.cs
@@ -1,11 +1,20 @@
 using System;
 
+using Microsoft.Qwiq.Credentials;
+
 namespace Microsoft.Qwiq
 {
     public interface ITfsTeamProjectCollection
     {
-        IIdentityManagementService IdentityManagementService { get; }
+        TfsCredentials AuthorizedCredentials { get; }
+
+        ITeamFoundationIdentity AuthorizedIdentity { get; }
+
         ICommonStructureService CommonStructureService { get; }
+
+        bool HasAuthenticated { get; }
+
+        IIdentityManagementService IdentityManagementService { get; }
     }
 
     internal interface IInternalTfsTeamProjectCollection : ITfsTeamProjectCollection, IDisposable
@@ -13,4 +22,3 @@ namespace Microsoft.Qwiq
         T GetService<T>();
     }
 }
-

--- a/src/Qwiq.Core/IWorkItemStore.cs
+++ b/src/Qwiq.Core/IWorkItemStore.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 
+using Microsoft.Qwiq.Credentials;
+
 namespace Microsoft.Qwiq
 {
     /// <summary>
@@ -9,6 +11,8 @@ namespace Microsoft.Qwiq
     /// </summary>
     public interface IWorkItemStore : IDisposable
     {
+        TfsCredentials AuthorizedCredentials { get; }
+
         IEnumerable<IProject> Projects { get; }
 
         ITfsTeamProjectCollection TeamProjectCollection { get; }

--- a/src/Qwiq.Core/IWorkItemStore.cs
+++ b/src/Qwiq.Core/IWorkItemStore.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace Microsoft.Qwiq
@@ -10,14 +9,26 @@ namespace Microsoft.Qwiq
     /// </summary>
     public interface IWorkItemStore : IDisposable
     {
-        IEnumerable<IWorkItem> Query(string wiql, bool dayPrecision = false);
-        IEnumerable<IWorkItemLinkInfo> QueryLinks(string wiql, bool dayPrecision = false);
-        IEnumerable<IWorkItem> Query(IEnumerable<int> ids, DateTime? asOf = null);
-        IWorkItem Query(int id, DateTime? asOf = null);
-        ITfsTeamProjectCollection TeamProjectCollection { get; }
         IEnumerable<IProject> Projects { get; }
-        IEnumerable<IWorkItemLinkType> WorkItemLinkTypes { get; }
+
+        ITfsTeamProjectCollection TeamProjectCollection { get; }
+
         TimeZone TimeZone { get; }
+
+        string UserDisplayName { get; }
+
+        string UserIdentityName { get; }
+
+        string UserSid { get; }
+
+        IEnumerable<IWorkItemLinkType> WorkItemLinkTypes { get; }
+
+        IEnumerable<IWorkItem> Query(string wiql, bool dayPrecision = false);
+
+        IEnumerable<IWorkItem> Query(IEnumerable<int> ids, DateTime? asOf = null);
+
+        IWorkItem Query(int id, DateTime? asOf = null);
+
+        IEnumerable<IWorkItemLinkInfo> QueryLinks(string wiql, bool dayPrecision = false);
     }
 }
-

--- a/src/Qwiq.Core/Proxies/TeamFoundationIdentityProxy.cs
+++ b/src/Qwiq.Core/Proxies/TeamFoundationIdentityProxy.cs
@@ -10,54 +10,54 @@ namespace Microsoft.Qwiq.Proxies
     {
         private readonly Tfs.TeamFoundationIdentity _identity;
 
+        private readonly Lazy<IIdentityDescriptor> _descriptor;
+
+        private readonly Lazy<IEnumerable<IIdentityDescriptor>> _memberOf;
+
+        private readonly Lazy<IEnumerable<IIdentityDescriptor>> _members;
+
         internal TeamFoundationIdentityProxy(Tfs.TeamFoundationIdentity identity)
         {
             _identity = identity;
+            _descriptor =
+                new Lazy<IIdentityDescriptor>(
+                    () =>
+                        ExceptionHandlingDynamicProxyFactory.Create<IIdentityDescriptor>(
+                            new IdentityDescriptorProxy(_identity?.Descriptor)));
+
+            _memberOf =
+                new Lazy<IEnumerable<IIdentityDescriptor>>(
+                    () =>
+                        _identity?.MemberOf.Select(
+                            item =>
+                                ExceptionHandlingDynamicProxyFactory.Create<IIdentityDescriptor>(
+                                    new IdentityDescriptorProxy(item))) ?? Enumerable.Empty<IIdentityDescriptor>());
+
+            _members =
+                new Lazy<IEnumerable<IIdentityDescriptor>>(
+                    () =>
+                        _identity?.Members.Select(
+                            item =>
+                                ExceptionHandlingDynamicProxyFactory.Create<IIdentityDescriptor>(
+                                    new IdentityDescriptorProxy(item))) ?? Enumerable.Empty<IIdentityDescriptor>());
         }
 
-        public IIdentityDescriptor Descriptor
-        {
-            get { return ExceptionHandlingDynamicProxyFactory.Create<IIdentityDescriptor>(new IdentityDescriptorProxy(_identity.Descriptor)); }
-        }
+        public IIdentityDescriptor Descriptor => _descriptor.Value;
 
-        public string DisplayName
-        {
-            get { return _identity.DisplayName; }
-        }
+        public string DisplayName => _identity?.DisplayName;
 
-        public bool IsActive
-        {
-            get { return _identity.IsActive; }
-        }
+        public bool IsActive => _identity?.IsActive ?? false;
 
-        public bool IsContainer
-        {
-            get { return _identity.IsContainer; }
-        }
+        public bool IsContainer => _identity?.IsContainer ?? false;
 
-        public IEnumerable<IIdentityDescriptor> MemberOf
-        {
-            get { return _identity.MemberOf.Select(item => ExceptionHandlingDynamicProxyFactory.Create<IIdentityDescriptor>(new IdentityDescriptorProxy(item))); }
-        }
+        public IEnumerable<IIdentityDescriptor> MemberOf => _memberOf.Value;
 
-        public IEnumerable<IIdentityDescriptor> Members
-        {
-            get { return _identity.Members.Select(item => ExceptionHandlingDynamicProxyFactory.Create<IIdentityDescriptor>(new IdentityDescriptorProxy(item))); }
-        }
+        public IEnumerable<IIdentityDescriptor> Members => _members.Value;
 
-        public Guid TeamFoundationId
-        {
-            get { return _identity.TeamFoundationId; }
-        }
+        public Guid TeamFoundationId => _identity?.TeamFoundationId ?? Guid.Empty;
 
-        public string UniqueName
-        {
-            get { return _identity.UniqueName; }
-        }
+        public string UniqueName => _identity?.UniqueName;
 
-        public int UniqueUserId
-        {
-            get { return _identity.UniqueUserId; }
-        }
+        public int UniqueUserId => _identity?.UniqueUserId ?? -1;
     }
 }

--- a/src/Qwiq.Core/Proxies/TfsTeamProjectCollectionProxy.cs
+++ b/src/Qwiq.Core/Proxies/TfsTeamProjectCollectionProxy.cs
@@ -1,49 +1,63 @@
 using System;
+
+using Microsoft.Qwiq.Credentials;
 using Microsoft.Qwiq.Exceptions;
+
 using Tfs = Microsoft.TeamFoundation;
 
 namespace Microsoft.Qwiq.Proxies
 {
     public class TfsTeamProjectCollectionProxy : IInternalTfsTeamProjectCollection
     {
+        private readonly Lazy<ICommonStructureService> _css;
+
+        private readonly Lazy<IIdentityManagementService> _ims;
+
         private readonly Tfs.Client.TfsTeamProjectCollection _tfs;
 
         internal TfsTeamProjectCollectionProxy(Tfs.Client.TfsTeamProjectCollection tfs)
         {
             _tfs = tfs;
+            _css =
+                new Lazy<ICommonStructureService>(
+                    () =>
+                        ExceptionHandlingDynamicProxyFactory.Create<ICommonStructureService>(
+                            new CommonStructureServiceProxy(_tfs?.GetService<Tfs.Server.ICommonStructureService4>())));
+            _ims =
+                new Lazy<IIdentityManagementService>(
+                    () =>
+                        ExceptionHandlingDynamicProxyFactory.Create<IIdentityManagementService>(
+                            new IdentityManagementServiceProxy(
+                                _tfs?.GetService<Tfs.Framework.Client.IIdentityManagementService2>())));
         }
 
-        public IIdentityManagementService IdentityManagementService
-        {
-            get
-            {
-                return ExceptionHandlingDynamicProxyFactory.Create<IIdentityManagementService>(new IdentityManagementServiceProxy(_tfs.GetService<Tfs.Framework.Client.IIdentityManagementService2>()));
-            }
-        }
+        public TfsCredentials AuthorizedCredentials => new TfsCredentials(_tfs?.ClientCredentials);
 
-        public ICommonStructureService CommonStructureService
-        {
-            get { return ExceptionHandlingDynamicProxyFactory.Create<ICommonStructureService>(new CommonStructureServiceProxy(_tfs.GetService<Tfs.Server.ICommonStructureService4>())); }
-        }
+        public ITeamFoundationIdentity AuthorizedIdentity => new TeamFoundationIdentityProxy(_tfs?.AuthorizedIdentity);
 
-        public T GetService<T>()
-        {
-            return _tfs.GetService<T>();
-        }
+        public ICommonStructureService CommonStructureService => _css.Value;
 
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                _tfs.Dispose();
-            }
-        }
+        public bool HasAuthenticated => _tfs?.HasAuthenticated ?? false;
+
+        public IIdentityManagementService IdentityManagementService => _ims.Value;
 
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
+
+        public T GetService<T>()
+        {
+            return _tfs == null ? default(T) : _tfs.GetService<T>();
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _tfs?.Dispose();
+            }
+        }
     }
 }
-

--- a/src/Qwiq.Core/Qwiq.Core.csproj
+++ b/src/Qwiq.Core/Qwiq.Core.csproj
@@ -243,10 +243,10 @@
     <Compile Include="IAttachment.cs" />
     <Compile Include="ICommonStructureService.cs" />
     <Compile Include="IdentitySearchFactor.cs" />
+    <Compile Include="IExternalLink.cs" />
     <Compile Include="IField.cs" />
     <Compile Include="IFieldCollection.cs" />
     <Compile Include="IFieldConflict.cs" />
-    <Compile Include="IExternalLink.cs" />
     <Compile Include="IHyperlink.cs" />
     <Compile Include="IIdentityDescriptor.cs" />
     <Compile Include="IIdentityManagementService.cs" />
@@ -277,10 +277,10 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Proxies\AttachmentProxy.cs" />
     <Compile Include="Proxies\CommonStructureServiceProxy.cs" />
+    <Compile Include="Proxies\ExternalLinkProxy.cs" />
     <Compile Include="Proxies\FieldCollectionProxy.cs" />
     <Compile Include="Proxies\FieldConflictProxy.cs" />
     <Compile Include="Proxies\FieldProxy.cs" />
-    <Compile Include="Proxies\ExternalLinkProxy.cs" />
     <Compile Include="Proxies\HyperlinkProxy.cs" />
     <Compile Include="Proxies\IdentityDescriptorProxy.cs" />
     <Compile Include="Proxies\IdentityManagementServiceProxy.cs" />

--- a/src/Qwiq.Linq/Qwiq.Linq.csproj
+++ b/src/Qwiq.Linq/Qwiq.Linq.csproj
@@ -244,7 +244,6 @@
     <Compile Include="Visitors\PartialEvaluator.cs" />
     <Compile Include="Visitors\QueryRewriter.cs" />
     <Compile Include="Visitors\WiqlQueryBuilder.cs" />
-    <Compile Include="WiqlExpressions\WasEverExpression.cs" />
     <Compile Include="WiqlExpressions\AsOfExpression.cs" />
     <Compile Include="WiqlExpressions\ContainsExpression.cs" />
     <Compile Include="WiqlExpressions\IndexerExpression.cs" />
@@ -253,6 +252,7 @@
     <Compile Include="WiqlExpressions\OrderOptions.cs" />
     <Compile Include="WiqlExpressions\SelectExpression.cs" />
     <Compile Include="WiqlExpressions\UnderExpression.cs" />
+    <Compile Include="WiqlExpressions\WasEverExpression.cs" />
     <Compile Include="WiqlExpressions\WhereExpression.cs" />
     <Compile Include="WiqlExpressions\WiqlExpressionType.cs" />
     <Compile Include="WiqlTranslator.cs" />

--- a/test/Qwiq.Core.Tests/Qwiq.Core.Tests.csproj
+++ b/test/Qwiq.Core.Tests/Qwiq.Core.Tests.csproj
@@ -215,7 +215,6 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.IdentityModel.Tokens.Jwt, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.4.0.0\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
@@ -224,26 +223,6 @@
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.2\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Runtime.Serialization.Primitives, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Runtime.Serialization.Primitives.4.1.1\lib\net46\System.Runtime.Serialization.Primitives.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Security.Cryptography.Algorithms.4.2.0\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Security.Cryptography.Encoding.4.0.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Security.Cryptography.Primitives.4.0.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Security.Cryptography.X509Certificates.4.1.0\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Web.Http, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.2\lib\net45\System.Web.Http.dll</HintPath>

--- a/test/Qwiq.Core.Tests/packages.config
+++ b/test/Qwiq.Core.Tests/packages.config
@@ -12,32 +12,6 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net46" />
   <package id="Should" version="1.1.20" targetFramework="net46" />
-  <package id="System.Collections" version="4.0.11" targetFramework="net46" />
-  <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net46" />
-  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net46" />
-  <package id="System.Globalization" version="4.0.11" targetFramework="net46" />
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.0" targetFramework="net46" />
-  <package id="System.IO" version="4.1.0" targetFramework="net46" />
-  <package id="System.Linq" version="4.1.0" targetFramework="net46" />
-  <package id="System.Net.Http" version="4.0.0" targetFramework="net46" />
-  <package id="System.Net.Primitives" version="4.0.11" targetFramework="net46" />
-  <package id="System.Reflection" version="4.1.0" targetFramework="net46" />
-  <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net46" />
-  <package id="System.Runtime" version="4.1.0" targetFramework="net46" />
-  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net46" />
-  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net46" />
-  <package id="System.Runtime.Serialization.Json" version="4.0.2" targetFramework="net46" />
-  <package id="System.Runtime.Serialization.Primitives" version="4.1.1" targetFramework="net46" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.2.0" targetFramework="net46" />
-  <package id="System.Security.Cryptography.Encoding" version="4.0.0" targetFramework="net46" />
-  <package id="System.Security.Cryptography.Primitives" version="4.0.0" targetFramework="net46" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.1.0" targetFramework="net46" />
-  <package id="System.Text.Encoding" version="4.0.11" targetFramework="net46" />
-  <package id="System.Text.Encoding.Extensions" version="4.0.11" targetFramework="net46" />
-  <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net46" />
-  <package id="System.Threading" version="4.0.11" targetFramework="net46" />
-  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net46" />
-  <package id="System.Xml.ReaderWriter" version="4.0.11" targetFramework="net46" />
-  <package id="System.Xml.XDocument" version="4.0.11" targetFramework="net46" />
   <package id="WindowsAzure.ServiceBus" version="2.5.1.0" targetFramework="net46" />
 </packages>

--- a/test/Qwiq.Mapper.Tests/Mocks/InstrumentedMockWorkItemStore.cs
+++ b/test/Qwiq.Mapper.Tests/Mocks/InstrumentedMockWorkItemStore.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 
+using Microsoft.Qwiq.Credentials;
+
 namespace Microsoft.Qwiq.Mapper.Tests.Mocks
 {
     internal class InstrumentedMockWorkItemStore : IWorkItemStore
@@ -11,6 +13,8 @@ namespace Microsoft.Qwiq.Mapper.Tests.Mocks
         {
             _innerWorkItemStore = innerWorkItemStore;
         }
+
+        public TfsCredentials AuthorizedCredentials => _innerWorkItemStore.AuthorizedCredentials;
 
         public IEnumerable<IProject> Projects
         {

--- a/test/Qwiq.Mapper.Tests/Mocks/InstrumentedMockWorkItemStore.cs
+++ b/test/Qwiq.Mapper.Tests/Mocks/InstrumentedMockWorkItemStore.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Qwiq.Mapper.Tests.Mocks
 {
-    class InstrumentedMockWorkItemStore : IWorkItemStore
+    internal class InstrumentedMockWorkItemStore : IWorkItemStore
     {
         private readonly IWorkItemStore _innerWorkItemStore;
 
@@ -11,6 +11,63 @@ namespace Microsoft.Qwiq.Mapper.Tests.Mocks
         {
             _innerWorkItemStore = innerWorkItemStore;
         }
+
+        public IEnumerable<IProject> Projects
+        {
+            get
+            {
+                ProjectsCallCount += 1;
+                return _innerWorkItemStore.Projects;
+            }
+        }
+
+        public int ProjectsCallCount { get; private set; }
+
+        public int QueryCallCount
+        {
+            get
+            {
+                return QueryIdCallCount + QueryIdsCallCount + QueryLinksCallCount + QueryStringCallCount;
+            }
+        }
+
+        public int QueryIdCallCount { get; private set; }
+
+        public int QueryIdsCallCount { get; private set; }
+
+        public int QueryLinksCallCount { get; private set; }
+
+        public int QueryStringCallCount { get; private set; }
+
+        public ITfsTeamProjectCollection TeamProjectCollection
+        {
+            get
+            {
+                TeamProjectCollectionCallCount += 1;
+                return _innerWorkItemStore.TeamProjectCollection;
+            }
+        }
+
+        public int TeamProjectCollectionCallCount { get; private set; }
+
+        public TimeZone TimeZone => _innerWorkItemStore.TimeZone;
+
+        public string UserDisplayName => _innerWorkItemStore.UserDisplayName;
+
+        public string UserIdentityName => _innerWorkItemStore.UserIdentityName;
+
+        public string UserSid => _innerWorkItemStore.UserSid;
+
+        public IEnumerable<IWorkItemLinkType> WorkItemLinkTypes
+        {
+            get
+            {
+                WorkItemLinkTypesCallCount += 1;
+                return _innerWorkItemStore.WorkItemLinkTypes;
+            }
+        }
+
+        public int WorkItemLinkTypesCallCount { get; private set; }
 
         public void Dispose()
         {
@@ -22,66 +79,23 @@ namespace Microsoft.Qwiq.Mapper.Tests.Mocks
             QueryStringCallCount += 1;
             return _innerWorkItemStore.Query(wiql, dayPrecision);
         }
-        public int QueryStringCallCount { get; private set; }
-
-        public IEnumerable<IWorkItemLinkInfo> QueryLinks(string wiql, bool dayPrecision = false)
-        {
-            QueryLinksCallCount += 1;
-            return _innerWorkItemStore.QueryLinks(wiql, dayPrecision);
-        }
-        public int QueryLinksCallCount { get; private set; }
 
         public IEnumerable<IWorkItem> Query(IEnumerable<int> ids, DateTime? asOf = null)
         {
             QueryIdsCallCount += 1;
             return _innerWorkItemStore.Query(ids, asOf);
         }
-        public int QueryIdsCallCount { get; private set; }
 
         public IWorkItem Query(int id, DateTime? asOf = null)
         {
             QueryIdCallCount += 1;
             return _innerWorkItemStore.Query(id, asOf);
         }
-        public int QueryIdCallCount { get; private set; }
 
-        public int QueryCallCount
+        public IEnumerable<IWorkItemLinkInfo> QueryLinks(string wiql, bool dayPrecision = false)
         {
-            get { return QueryIdCallCount + QueryIdsCallCount + QueryLinksCallCount + QueryStringCallCount; }
+            QueryLinksCallCount += 1;
+            return _innerWorkItemStore.QueryLinks(wiql, dayPrecision);
         }
-
-        public ITfsTeamProjectCollection TeamProjectCollection
-        {
-            get
-            {
-                TeamProjectCollectionCallCount += 1;
-                return _innerWorkItemStore.TeamProjectCollection;
-            }
-        }
-        public int TeamProjectCollectionCallCount { get; private set; }
-
-        public IEnumerable<IProject> Projects
-        {
-            get
-            {
-                ProjectsCallCount += 1;
-                return _innerWorkItemStore.Projects;
-            }
-        }
-        public int ProjectsCallCount { get; private set; }
-
-        public IEnumerable<IWorkItemLinkType> WorkItemLinkTypes
-        {
-            get
-            {
-                WorkItemLinkTypesCallCount += 1;
-                return _innerWorkItemStore.WorkItemLinkTypes;
-            }
-        }
-
-        public TimeZone TimeZone => _innerWorkItemStore.TimeZone;
-
-        public int WorkItemLinkTypesCallCount { get; private set; }
     }
 }
-

--- a/test/Qwiq.Mocks/MockTfsTeamProjectCollection.cs
+++ b/test/Qwiq.Mocks/MockTfsTeamProjectCollection.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Xml;
+using Microsoft.Qwiq.Credentials;
 
 namespace Microsoft.Qwiq.Mocks
 {
@@ -17,7 +14,13 @@ namespace Microsoft.Qwiq.Mocks
             IdentityManagementService = identityManagementService;
         }
 
+        public TfsCredentials AuthorizedCredentials { get; set; }
+
+        public ITeamFoundationIdentity AuthorizedIdentity { get; set; }
+
         public ICommonStructureService CommonStructureService { get; set; }
+
+        public bool HasAuthenticated { get; set; }
 
         public IIdentityManagementService IdentityManagementService { get; set; }
     }

--- a/test/Qwiq.Mocks/MockWorkItemStore.cs
+++ b/test/Qwiq.Mocks/MockWorkItemStore.cs
@@ -10,13 +10,13 @@ namespace Microsoft.Qwiq.Mocks
 {
     public class MockWorkItemStore : IWorkItemStore
     {
-        private readonly IEnumerable<IWorkItemLinkInfo> _links;
+        private static readonly Random Instance = new Random();
 
-        private readonly IList<IWorkItem> _workItems;
+        private readonly IEnumerable<IWorkItemLinkInfo> _links;
 
         private readonly IDictionary<int, IWorkItem> _lookup;
 
-        private static readonly Random Instance = new Random();
+        private readonly IList<IWorkItem> _workItems;
 
         public MockWorkItemStore()
             : this(new MockTfsTeamProjectCollection(), new MockProject())
@@ -47,8 +47,8 @@ namespace Microsoft.Qwiq.Mocks
             _lookup = _workItems.ToDictionary(k => k.Id, e => e);
         }
 
-        public MockWorkItemStore(IEnumerable<IWorkItem> workItems, IEnumerable<IWorkItemLinkInfo> links )
-            :this(workItems)
+        public MockWorkItemStore(IEnumerable<IWorkItem> workItems, IEnumerable<IWorkItemLinkInfo> links)
+            : this(workItems)
         {
             _links = links;
         }
@@ -62,13 +62,21 @@ namespace Microsoft.Qwiq.Mocks
 
         public IEnumerable<IProject> Projects { get; set; }
 
-        public ITfsTeamProjectCollection TeamProjectCollection { get; set; }
+        public bool SimulateQueryTimes { get; set; }
 
-        public IEnumerable<IWorkItemLinkType> WorkItemLinkTypes { get { return CoreLinkTypeReferenceNames.All.Select(s => new MockWorkItemLinkType(s)); } }
+        public ITfsTeamProjectCollection TeamProjectCollection { get; set; }
 
         public TimeZone TimeZone { get; }
 
-        public bool SimulateQueryTimes { get; set; }
+        public IEnumerable<IWorkItemLinkType> WorkItemLinkTypes
+        {
+            get
+            {
+                return CoreLinkTypeReferenceNames.All.Select(s => new MockWorkItemLinkType(s));
+            }
+        }
+
+        private int WaitTime => Instance.Next(0, 3000);
 
         public void Dispose()
         {
@@ -107,10 +115,7 @@ namespace Microsoft.Qwiq.Mocks
                 Thread.Sleep(sleep);
             }
 
-            return _lookup
-                    .Where(p => h.Contains(p.Key))
-                    .Select(p => p.Value)
-                    .ToList();
+            return _lookup.Where(p => h.Contains(p.Key)).Select(p => p.Value).ToList();
         }
 
         public IWorkItem Query(int id, DateTime? asOf = null)
@@ -137,6 +142,10 @@ namespace Microsoft.Qwiq.Mocks
             }
         }
 
-        private int WaitTime => Instance.Next(0, 3000);
+        public string UserDisplayName => string.Empty;
+
+        public string UserIdentityName => string.Empty;
+
+        public string UserSid => string.Empty;
     }
 }

--- a/test/Qwiq.Mocks/MockWorkItemStore.cs
+++ b/test/Qwiq.Mocks/MockWorkItemStore.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 
+using Microsoft.Qwiq.Credentials;
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
 
 namespace Microsoft.Qwiq.Mocks
@@ -60,6 +61,8 @@ namespace Microsoft.Qwiq.Mocks
             _lookup = _workItems.ToDictionary(k => k.Id, e => e);
         }
 
+        public TfsCredentials AuthorizedCredentials => null;
+
         public IEnumerable<IProject> Projects { get; set; }
 
         public bool SimulateQueryTimes { get; set; }
@@ -67,6 +70,12 @@ namespace Microsoft.Qwiq.Mocks
         public ITfsTeamProjectCollection TeamProjectCollection { get; set; }
 
         public TimeZone TimeZone { get; }
+
+        public string UserDisplayName => TeamProjectCollection.AuthorizedIdentity.DisplayName;
+
+        public string UserIdentityName => TeamProjectCollection.AuthorizedIdentity.DisplayName;
+
+        public string UserSid => TeamProjectCollection.AuthorizedIdentity.Descriptor.Identifier;
 
         public IEnumerable<IWorkItemLinkType> WorkItemLinkTypes
         {
@@ -141,11 +150,5 @@ namespace Microsoft.Qwiq.Mocks
             {
             }
         }
-
-        public string UserDisplayName => string.Empty;
-
-        public string UserIdentityName => string.Empty;
-
-        public string UserSid => string.Empty;
     }
 }


### PR DESCRIPTION
Proposed changes
--


 - **Add support for lazy invocation of credentials**. Since the enumeration yields credentials to try, the caller does not need to eagerly resolve all potential arguments as they may not be used.
 - **Add support for `AuthorizedCredentials` and `AuthorizedIdentity`**. After a `TfsTeamProjectCollection` is connected, the credentials and identity are exposed to the caller. This is especially useful when troubleshooting and using the `CredentialsFactory` where it is not known which credential was used.
 - **Support null ctor objects in common proxies**. Internal `.ctor` methods wrap TFS native objects; however, there is no argument checking for parameters.  Subsequent methods could then be called causing an unhandled `NullReferenceException`.
 - **Lazy load properties on `TeamFoundationIdentityProxy`**. Each time the `Descriptor`, `MemberOf`, or `Members` property is invoked on `TeamFoundationIdentityProxy`, a new set of exception handling proxies are created and returned to the caller. The items have been moved to a Lazy functor to load once when a caller makes the invocation.
 - **`WorkItemsStoreProxy` lazy loads**. Most items in `WorksItemsStoreProxy` are not required at construction time. For example, if no caller is performing queries, there is no need to retrieve an instance of `WorkItemStore`.