### PR TITLE
Feature/type parsing without first chance exception

### DIFF
--- a/src/Qwiq.Core/ITypeParser.cs
+++ b/src/Qwiq.Core/ITypeParser.cs
@@ -1,12 +1,13 @@
 using System;
+using JetBrains.Annotations;
 
 namespace Microsoft.Qwiq
 {
     public interface ITypeParser
     {
-        object Parse(Type destinationType, object value, object defaultValue);
-        object Parse(Type destinationType, object input);
-        T Parse<T>(object value);
-        T Parse<T>(object value, T defaultValue);
+        object Parse([CanBeNull] Type destinationType, [CanBeNull] object value, [CanBeNull] object defaultValue);
+        object Parse([CanBeNull] Type destinationType, [CanBeNull] object input);
+        T Parse<T>([CanBeNull] object value);
+        T Parse<T>([CanBeNull] object value, [CanBeNull] T defaultValue);
     }
 }

--- a/src/Qwiq.Core/IdentityDescriptor.cs
+++ b/src/Qwiq.Core/IdentityDescriptor.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Qwiq
 
         public int CompareTo(IdentityDescriptor other)
         {
-            if (Equals(this, other)) return 0;
+            if (this == other) return 0;
             if (this == null && other != null) return -1;
             if (this != null && other == null) return 1;
 

--- a/src/Qwiq.Core/Qwiq.Core.csproj
+++ b/src/Qwiq.Core/Qwiq.Core.csproj
@@ -192,6 +192,7 @@
     <Compile Include="TeamFoundationIdentity.cs" />
     <Compile Include="TeamFoundationIdentityComparer.cs" />
     <Compile Include="TfsConnectionFactory.cs" />
+    <Compile Include="TypeExtensions.cs" />
     <Compile Include="TypeParser.cs" />
     <Compile Include="ValidationState.cs" />
     <Compile Include="WiqlConstants.cs" />

--- a/src/Qwiq.Core/TypeExtensions.cs
+++ b/src/Qwiq.Core/TypeExtensions.cs
@@ -1,0 +1,81 @@
+﻿using System.Collections.Generic;
+using JetBrains.Annotations;
+
+namespace System
+{
+    public static class TypeExtensions
+    {
+        // Default values of value types return by the default ctor
+        // See https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/default-values-table
+        private static readonly Dictionary<Type, object> DefaultValuesForTypes = new Dictionary<Type, object>
+        {
+            [typeof(bool)] = false,
+            [typeof(bool?)] = null,
+            [typeof(byte)] = (byte)0,
+            [typeof(byte?)] = null,
+            [typeof(char)] = '\0',
+            [typeof(decimal)] = 0.0M,
+            [typeof(decimal?)] = null,
+            [typeof(double)] = 0.0D,
+            [typeof(double?)] = null,
+            [typeof(float)] = 0.0F,
+            [typeof(float?)] = null,
+            [typeof(int)] = 0,
+            [typeof(int?)] = null,
+            [typeof(long)] = 0L,
+            [typeof(long?)] = null,
+            [typeof(sbyte)] = (sbyte)0,
+            [typeof(sbyte?)] = null,
+            [typeof(short)] = (short)0,
+            [typeof(short?)] = null,
+            [typeof(uint)] = (uint)0,
+            [typeof(uint?)] = null,
+            [typeof(ulong)] = (ulong)0,
+            [typeof(ulong?)] = null,
+            [typeof(ushort)] = (ushort)0,
+            [typeof(ushort?)] = null,
+            [typeof(DateTime)] = DateTime.MinValue,
+            [typeof(DateTime?)] = null,
+            [typeof(DateTimeOffset)] = DateTimeOffset.MinValue,
+            [typeof(DateTimeOffset?)] = null,
+        };
+
+        public static bool CanAcceptNull([NotNull] this Type type)
+        {
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
+            if (IsGenericNullable(type))
+            {
+                return true;
+            }
+
+            switch (Type.GetTypeCode(type))
+            {
+                case TypeCode.Object:
+                case TypeCode.String:
+                    return true;
+            }
+
+            return false;
+        }
+
+        [CanBeNull]
+        public static object GetDefaultValueOfType([NotNull] this Type type)
+        {
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
+            if (DefaultValuesForTypes.TryGetValue(type, out object retval))
+            {
+                return retval;
+            }
+
+            return type.IsValueType ? Activator.CreateInstance(type) : null;
+        }
+
+        public static bool IsGenericNullable([NotNull] this Type type)
+        {
+            if (type == null) throw new ArgumentNullException(nameof(type));
+            return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+        }
+    }
+}

--- a/src/Qwiq.Core/TypeParser.cs
+++ b/src/Qwiq.Core/TypeParser.cs
@@ -1,3 +1,4 @@
+using JetBrains.Annotations;
 using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
@@ -17,11 +18,13 @@ namespace Microsoft.Qwiq
 
         public object Parse(Type destinationType, object value, object defaultValue)
         {
+            if (destinationType == null) throw new ArgumentNullException(nameof(destinationType));
             return ParseImpl(destinationType, value, defaultValue);
         }
 
         public object Parse(Type destinationType, object input)
         {
+            if (destinationType == null) throw new ArgumentNullException(nameof(destinationType));
             return ParseImpl(destinationType, input);
         }
 
@@ -45,31 +48,93 @@ namespace Microsoft.Qwiq
             return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>).GetGenericTypeDefinition();
         }
 
-        private static object ParseImpl(Type destinationType, object value)
+        [CanBeNull]
+        private static object ParseImpl([NotNull] Type destinationType, [CanBeNull] object value)
         {
-            var defaultValueFactory = new Lazy<object>(() => GetDefaultValueOfType(destinationType));
-
             // If the incoming value is null, return the default value
-            if (ValueRepresentsNull(value)) return defaultValueFactory.Value;
+            if (ValueRepresentsNull(value)) return GetDefaultValueOfType(destinationType);
+
+            var valueType = value.GetType();
 
             // Quit if no type conversion is actually required
-            if (value.GetType() == destinationType) return value;
+            if (valueType == destinationType) return value;
             if (destinationType.IsInstanceOfType(value)) return value;
+
+            switch (Type.GetTypeCode(destinationType))
+            {
+                case TypeCode.Boolean:
+                case TypeCode.SByte:
+                case TypeCode.Byte:
+                case TypeCode.Int16:
+                case TypeCode.UInt16:
+                case TypeCode.Int32:
+                case TypeCode.UInt32:
+                case TypeCode.Int64:
+                case TypeCode.UInt64:
+                case TypeCode.Single:
+                case TypeCode.Double:
+                case TypeCode.Decimal:
+                case TypeCode.DateTime:
+                    var destNullable = IsGenericNullable(destinationType);
+                    if (!destNullable && valueType == typeof(string))
+                    {
+                        var val = (string)value;
+                        if (string.IsNullOrEmpty(val))
+                        {
+                            return GetDefaultValueOfType(destinationType);
+                        }
+                    }
+                    break;
+            }
+
             if (TryConvert(destinationType, value, out object result)) return result;
-            if (IsGenericNullable(destinationType) && defaultValueFactory.Value == null) return null;
-            if (TryConvert(destinationType, defaultValueFactory.Value, out result)) return result;
+
+            var defaultValue = GetDefaultValueOfType(destinationType);
+            if (IsGenericNullable(destinationType) && defaultValue == null) return null;
+            if (TryConvert(destinationType, defaultValue, out result)) return result;
 
             return null;
         }
 
-        private static object ParseImpl(Type destinationType, object value, object defaultValue)
+        [CanBeNull]
+        private static object ParseImpl([NotNull] Type destinationType, [CanBeNull] object value, [CanBeNull] object defaultValue)
         {
             // If the incoming value is null, return the default value
             if (ValueRepresentsNull(value)) return defaultValue;
 
+            var valueType = value.GetType();
+
             // Quit if no type conversion is actually required
-            if (value.GetType() == destinationType) return value;
+            if (valueType == destinationType) return value;
             if (destinationType.IsInstanceOfType(value)) return value;
+
+            switch (Type.GetTypeCode(destinationType))
+            {
+                case TypeCode.Boolean:
+                case TypeCode.SByte:
+                case TypeCode.Byte:
+                case TypeCode.Int16:
+                case TypeCode.UInt16:
+                case TypeCode.Int32:
+                case TypeCode.UInt32:
+                case TypeCode.Int64:
+                case TypeCode.UInt64:
+                case TypeCode.Single:
+                case TypeCode.Double:
+                case TypeCode.Decimal:
+                case TypeCode.DateTime:
+                    var destNullable = IsGenericNullable(destinationType);
+                    if (!destNullable && valueType == typeof(string))
+                    {
+                        var val = (string)value;
+                        if (string.IsNullOrEmpty(val))
+                        {
+                            return defaultValue;
+                        }
+                    }
+                    break;
+            }
+
             if (TryConvert(destinationType, value, out object result)) return result;
             if (IsGenericNullable(destinationType) && defaultValue == null) return null;
             if (TryConvert(destinationType, defaultValue, out result)) return result;
@@ -88,7 +153,7 @@ namespace Microsoft.Qwiq
                 }
                 // ReSharper disable CatchAllClause
                 catch
-                        // ReSharper restore CatchAllClause
+                // ReSharper restore CatchAllClause
                 {
                 }
 
@@ -102,7 +167,7 @@ namespace Microsoft.Qwiq
                 }
                 // ReSharper disable CatchAllClause
                 catch
-                        // ReSharper restore CatchAllClause
+                // ReSharper restore CatchAllClause
                 {
                 }
 
@@ -115,7 +180,7 @@ namespace Microsoft.Qwiq
                 }
                 // ReSharper disable CatchAllClause
                 catch
-                        // ReSharper restore CatchAllClause
+                // ReSharper restore CatchAllClause
                 {
                 }
 
@@ -131,7 +196,7 @@ namespace Microsoft.Qwiq
                         }
                         // ReSharper disable EmptyGeneralCatchClause
                         catch
-                                // ReSharper restore EmptyGeneralCatchClause
+                        // ReSharper restore EmptyGeneralCatchClause
                         {
                         }
             }
@@ -140,14 +205,15 @@ namespace Microsoft.Qwiq
             return false;
         }
 
-        private static bool ValueRepresentsNull(object value)
+        [ContractAnnotation("value:null => true")]
+        private static bool ValueRepresentsNull([CanBeNull] object value)
         {
             return value == null || value == DBNull.Value;
         }
 
         // ReSharper disable ClassNeverInstantiated.Local
         private class Nested
-                // ReSharper restore ClassNeverInstantiated.Local
+        // ReSharper restore ClassNeverInstantiated.Local
         {
             // ReSharper disable MemberHidesStaticFromOuterClass
             internal static readonly ITypeParser Instance = new TypeParser();

--- a/src/Qwiq.Mapper/AttributeMapException.cs
+++ b/src/Qwiq.Mapper/AttributeMapException.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Microsoft.Qwiq.Mapper
+{
+    public class AttributeMapException : Exception
+    {
+        public AttributeMapException()
+        {
+        }
+
+        public AttributeMapException(string message)
+            :base(message)
+        {
+        }
+
+        public AttributeMapException(string message, Exception inner)
+            :base(message, inner)
+        {
+
+        }
+    }
+}

--- a/src/Qwiq.Mapper/Attributes/AttributeMapperStrategy.cs
+++ b/src/Qwiq.Mapper/Attributes/AttributeMapperStrategy.cs
@@ -1,4 +1,5 @@
 using FastMember;
+using JetBrains.Annotations;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -10,22 +11,120 @@ namespace Microsoft.Qwiq.Mapper.Attributes
 {
     public class AttributeMapperStrategy : WorkItemMapperStrategyBase
     {
-        private readonly IPropertyInspector _inspector;
-        private readonly ITypeParser _typeParser;
-        private static readonly ConcurrentDictionary<PropertyInfo, FieldDefinitionAttribute> PropertyInfoFields = new ConcurrentDictionary<PropertyInfo, FieldDefinitionAttribute>();
         private static readonly ConcurrentDictionary<Tuple<string, RuntimeTypeHandle>, List<PropertyInfo>> PropertiesThatExistOnWorkItem = new ConcurrentDictionary<Tuple<string, RuntimeTypeHandle>, List<PropertyInfo>>();
+        private static readonly ConcurrentDictionary<PropertyInfo, FieldDefinitionAttribute> PropertyInfoFields = new ConcurrentDictionary<PropertyInfo, FieldDefinitionAttribute>();
+        [NotNull] private readonly IPropertyInspector _inspector;
+        [NotNull] private readonly ITypeParser _typeParser;
 
-        public AttributeMapperStrategy(IPropertyInspector inspector, ITypeParser typeParser)
+
+        public AttributeMapperStrategy([NotNull] IPropertyInspector inspector)
+            : this(inspector, TypeParser.Default)
         {
-            _inspector = inspector;
-            _typeParser = typeParser;
         }
 
-        private static FieldDefinitionAttribute PropertyInfoFieldCache(IPropertyInspector inspector, PropertyInfo property)
+        public AttributeMapperStrategy([NotNull] IPropertyInspector inspector, [NotNull] ITypeParser typeParser)
         {
-            return PropertyInfoFields.GetOrAdd(
-                property,
-                info => inspector.GetAttribute<FieldDefinitionAttribute>(property));
+            _typeParser = typeParser ?? throw new ArgumentNullException(nameof(typeParser));
+            _inspector = inspector ?? throw new ArgumentNullException(nameof(inspector));
+        }
+
+        public override void Map<T>(IEnumerable<KeyValuePair<IWorkItem, T>> workItemMappings, IWorkItemMapper workItemMapper)
+        {
+            var targetWorkItemType = typeof(T);
+
+            foreach (var workItemMapping in workItemMappings)
+            {
+                var sourceWorkItem = workItemMapping.Key;
+                var targetWorkItem = workItemMapping.Value;
+
+                MapImpl(targetWorkItemType, sourceWorkItem, targetWorkItem);
+            }
+        }
+
+        public override void Map(Type targetWorkItemType, IEnumerable<KeyValuePair<IWorkItem, IIdentifiable<int?>>> workItemMappings, IWorkItemMapper workItemMapper)
+        {
+            foreach (var workItemMapping in workItemMappings)
+            {
+                var sourceWorkItem = workItemMapping.Key;
+                var targetWorkItem = workItemMapping.Value;
+
+                MapImpl(targetWorkItemType, sourceWorkItem, targetWorkItem);
+            }
+        }
+
+        protected internal virtual void AssignFieldValue(
+            [NotNull] Type targetWorkItemType,
+            [NotNull] IWorkItem sourceWorkItem,
+            [NotNull] object targetWorkItem,
+            [NotNull] PropertyInfo property,
+            [NotNull] string fieldName,
+            bool convert,
+            [CanBeNull] object nullSub,
+            [CanBeNull] object fieldValue)
+        {
+            // Coalesce fieldValue and nullSub
+
+            if (fieldValue == null && nullSub != null)
+            {
+                fieldValue = nullSub;
+            }
+            else
+            {
+                if (fieldValue is string value && string.IsNullOrWhiteSpace(value))
+                    fieldValue = nullSub;
+            }
+
+            var destType = property.PropertyType;
+
+            if (fieldValue == null && destType.IsValueType)
+            {
+                // Value types do not accept null; don't do any work
+                return;
+            }
+
+            if (fieldValue == null && destType.CanAcceptNull())
+            {
+                // Destination is a nullable or can take null; don't do any work
+                return;
+            }
+
+            var sourceType = fieldValue.GetType();
+            if (convert)
+            {
+                try
+                {
+                    fieldValue = _typeParser.Parse(destType, fieldValue);
+                }
+                catch (Exception e)
+                {
+                    throw new AttributeMapException($"Unable to convert field {fieldName} on work item {sourceWorkItem.Id}: {sourceWorkItem.WorkItemType} to property {property.Name} on {targetWorkItemType}.", e);
+                }
+            }
+
+            var accessor = TypeAccessor.Create(targetWorkItemType, true);
+            accessor[targetWorkItem, property.Name] = fieldValue;
+        }
+
+        protected internal virtual void MapImpl(Type targetWorkItemType, IWorkItem sourceWorkItem, object targetWorkItem)
+        {
+            var properties = PropertiesOnWorkItemCache(
+                _inspector,
+                sourceWorkItem,
+                targetWorkItemType,
+                typeof(FieldDefinitionAttribute));
+
+            foreach (var property in properties)
+            {
+                var a = PropertyInfoFieldCache(_inspector, property);
+                if (a == null) continue;
+
+                var fieldName = a.FieldName;
+                var convert = a.RequireConversion;
+                var nullSub = a.NullSubstitute;
+                var fieldValue = sourceWorkItem[fieldName];
+
+                AssignFieldValue(targetWorkItemType, sourceWorkItem, targetWorkItem, property, fieldName, convert, nullSub, fieldValue);
+            }
         }
 
         private static IEnumerable<PropertyInfo> PropertiesOnWorkItemCache(IPropertyInspector inspector, IWorkItem workItem, Type targetType, Type attributeType)
@@ -52,123 +151,11 @@ namespace Microsoft.Qwiq.Mapper.Attributes
                     });
         }
 
-        public override void Map<T>(IEnumerable<KeyValuePair<IWorkItem, T>> workItemMappings, IWorkItemMapper workItemMapper)
+        private static FieldDefinitionAttribute PropertyInfoFieldCache(IPropertyInspector inspector, PropertyInfo property)
         {
-            var targetWorkItemType = typeof(T);
-            var accessor = TypeAccessor.Create(targetWorkItemType, true);
-
-            foreach (var workItemMapping in workItemMappings)
-            {
-                var sourceWorkItem = workItemMapping.Key;
-                var targetWorkItem = workItemMapping.Value;
-
-                MapImpl(targetWorkItemType, sourceWorkItem, accessor, targetWorkItem);
-            }
-        }
-
-        public override void Map(Type targetWorkItemType, IEnumerable<KeyValuePair<IWorkItem, IIdentifiable<int?>>> workItemMappings, IWorkItemMapper workItemMapper)
-        {
-            var accessor = TypeAccessor.Create(targetWorkItemType, true);
-
-            foreach (var workItemMapping in workItemMappings)
-            {
-                var sourceWorkItem = workItemMapping.Key;
-                var targetWorkItem = workItemMapping.Value;
-
-                MapImpl(targetWorkItemType, sourceWorkItem, accessor, targetWorkItem);
-            }
-        }
-
-        private void MapImpl(Type targetWorkItemType, IWorkItem sourceWorkItem, TypeAccessor accessor, object targetWorkItem)
-        {
-#if DEBUG
-            Trace.TraceInformation("{0}: Mapping {1}", GetType().Name, sourceWorkItem.Id);
-#endif
-            var properties = PropertiesOnWorkItemCache(
-                _inspector,
-                sourceWorkItem,
-                targetWorkItemType,
-                typeof(FieldDefinitionAttribute));
-
-            foreach (var property in properties)
-            {
-                var a = PropertyInfoFieldCache(_inspector, property);
-                if (a == null) continue;
-
-                var fieldName = a.FieldName;
-                var convert = a.RequireConversion;
-                var nullSub = a.NullSubstitute;
-                var fieldValue = sourceWorkItem[fieldName];
-
-                try
-                {
-                    if (convert)
-                    {
-                        try
-                        {
-                            fieldValue = _typeParser.Parse(property.PropertyType, fieldValue, nullSub);
-                        }
-                        catch (Exception)
-                        {
-                            try
-                            {
-                                Trace.TraceWarning(
-                                    "Could not convert value of field '{0}' ({1}) to type {2}",
-                                    fieldName,
-                                    fieldValue.GetType().Name,
-                                    property.PropertyType.Name);
-                            }
-                            catch (Exception)
-                            {
-                                // Best effort
-                            }
-                        }
-                    }
-
-                    if (fieldValue == null && nullSub != null)
-                    {
-                        fieldValue = nullSub;
-                    }
-
-                    accessor[targetWorkItem, property.Name] = fieldValue;
-
-                }
-                catch(NullReferenceException) when (fieldValue == null)
-                {
-                    // This is most likely the cause of the field being null and the target property type not accepting nulls
-                    // For example: mapping null to an int instead of int?
-
-                    try
-                    {
-                        Trace.TraceWarning(
-                            "Could not map field '{0}' from type '{1}' to type '{2}'. Target '{2}.{3}' does not accept null values.",
-                            fieldName,
-                            sourceWorkItem.Type.Name,
-                            targetWorkItemType.Name,
-                            $"{property.Name} ({property.PropertyType.FullName})");
-                    }
-                    catch (Exception)
-                    {
-                        // Best effort
-                    }
-                }
-                catch (Exception e)
-                {
-                    try
-                    {
-                        Trace.TraceWarning(
-                            "Could not map field '{0}' from type '{1}' to type '{2}'. {3}",
-                            fieldName,
-                            sourceWorkItem.Type.Name,
-                            targetWorkItemType.Name,
-                            e.Message);
-                    }
-                    catch (Exception)
-                    {
-                        // Best effort
-                    }
-                }
-            }
+            return PropertyInfoFields.GetOrAdd(
+                property,
+                info => inspector.GetAttribute<FieldDefinitionAttribute>(property));
         }
     }
 }

--- a/src/Qwiq.Mapper/Attributes/NoExceptionAttributeMapperStrategy.cs
+++ b/src/Qwiq.Mapper/Attributes/NoExceptionAttributeMapperStrategy.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Diagnostics;
+using System.Reflection;
+using JetBrains.Annotations;
+
+namespace Microsoft.Qwiq.Mapper.Attributes
+{
+    public class NoExceptionAttributeMapperStrategy : AttributeMapperStrategy
+    {
+        public NoExceptionAttributeMapperStrategy([NotNull] IPropertyInspector inspector) : base(inspector)
+        {
+        }
+
+        public NoExceptionAttributeMapperStrategy([NotNull] IPropertyInspector inspector, [NotNull] ITypeParser typeParser)
+            :base(inspector, typeParser)
+        {
+
+        }
+
+        protected internal override void AssignFieldValue(Type targetWorkItemType, IWorkItem sourceWorkItem, object targetWorkItem, PropertyInfo property, string fieldName, bool convert, object nullSub, object fieldValue)
+        {
+            try
+            {
+                base.AssignFieldValue(targetWorkItemType, sourceWorkItem, targetWorkItem, property, fieldName, convert, nullSub, fieldValue);
+            }
+            catch (NullReferenceException) when (fieldValue == null)
+            {
+                // This is most likely the cause of the field being null and the target property type not accepting nulls
+                // For example: mapping null to an int instead of int?
+
+                try
+                {
+                    Trace.TraceWarning(
+                        "Could not map field '{0}' from type '{1}' to type '{2}'. Target '{2}.{3}' does not accept null values.",
+                        fieldName,
+                        sourceWorkItem.WorkItemType,
+                        targetWorkItemType.Name,
+                        $"{property.Name} ({property.PropertyType.FullName})");
+                }
+                catch (Exception)
+                {
+                    // Best effort
+                }
+            }
+            catch (Exception e)
+            {
+                try
+                {
+                    Trace.TraceWarning(
+                        "Could not map field '{0}' from type '{1}' to type '{2}.{3}'. {4}",
+                        fieldName,
+                        sourceWorkItem.WorkItemType,
+                        targetWorkItemType.Name,
+                        $"{property.Name} ({property.PropertyType.FullName})",
+                        e.Message);
+                }
+                catch (Exception)
+                {
+                    // Best effort
+                }
+            }
+        }
+    }
+}

--- a/src/Qwiq.Mapper/Qwiq.Mapper.csproj
+++ b/src/Qwiq.Mapper/Qwiq.Mapper.csproj
@@ -29,6 +29,7 @@
       <Link>Properties\AssemblyInfo.Common.cs</Link>
     </Compile>
     <Compile Include="Attributes\AttributeMapperStrategy.cs" />
+    <Compile Include="Attributes\NoExceptionAttributeMapperStrategy.cs" />
     <Compile Include="Attributes\FieldDefinitionAttribute.cs" />
     <Compile Include="Attributes\IPropertyInspector.cs" />
     <Compile Include="Attributes\IPropertyReflector.cs" />
@@ -42,6 +43,7 @@
     <Compile Include="IIdentifiable.cs" />
     <Compile Include="IWorkItemMapper.cs" />
     <Compile Include="IWorkItemMapperStrategy.cs" />
+    <Compile Include="AttributeMapException.cs" />
     <Compile Include="MapperTeamFoundationServerWorkItemQueryProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="WorkItemMapper.cs" />

--- a/test/Qwiq.Core.Tests/Qwiq.Core.UnitTests.csproj
+++ b/test/Qwiq.Core.Tests/Qwiq.Core.UnitTests.csproj
@@ -205,6 +205,7 @@
     <Compile Include="Mocks\MockException.cs" />
     <Compile Include="Mocks\MockVssExceptionMapper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TypeParser\TypeParserFirstChanceExceptionContext.cs" />
     <Compile Include="TypeParser\TypeParserTests.cs" />
     <Compile Include="TypeParser\TypeParserTestsContext.cs" />
     <Compile Include="WorkItemStore\WorkItem\WorkItemLinkTypeComparerTests.cs" />

--- a/test/Qwiq.Core.Tests/TypeParser/TypeParserFirstChanceExceptionContext.cs
+++ b/test/Qwiq.Core.Tests/TypeParser/TypeParserFirstChanceExceptionContext.cs
@@ -1,0 +1,28 @@
+using System;
+using JetBrains.Annotations;
+
+namespace Microsoft.Qwiq
+{
+    public abstract class TypeParserFirstChanceExceptionContext : TypeParserTestsContext
+    {
+        [CanBeNull]
+        public Exception FirstChanceException { get; set; }
+
+        public override void Given()
+        {
+            base.Given();
+            AppDomain.CurrentDomain.FirstChanceException += CurrentDomain_FirstChanceException;
+        }
+
+        public override void Cleanup()
+        {
+            base.Cleanup();
+            AppDomain.CurrentDomain.FirstChanceException -= CurrentDomain_FirstChanceException;
+        }
+
+        private void CurrentDomain_FirstChanceException(object sender, System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs e)
+        {
+            FirstChanceException = e.Exception;
+        }
+    }
+}

--- a/test/Qwiq.Core.Tests/TypeParser/TypeParserTests.cs
+++ b/test/Qwiq.Core.Tests/TypeParser/TypeParserTests.cs
@@ -25,12 +25,58 @@ namespace Microsoft.Qwiq
 
     [TestClass]
     // ReSharper disable once InconsistentNaming
-    public class when_parsing_an_enum_value : TypeParserTestsContext
+    public class when_parsing_an_enum_value_Generic : TypeParserTestsContext
     {
         public override void When()
         {
             Expected = Formatting.Indented;
             Actual = Parser.Parse("Indented", Formatting.None);
+        }
+
+        [TestMethod]
+        public void enum_value_is_returned()
+        {
+            Actual.ShouldEqual(Expected);
+        }
+    }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
+    public class when_parsing_an_enum_value_null_with_defaultValue : TypeParserTestsContext
+    {
+        public override void When()
+        {
+            Expected = (Formatting)0;
+            Actual = Parser.Parse(typeof(Formatting), null, Formatting.None);
+        }
+
+        [TestMethod]
+        public void enum_value_is_returned()
+        {
+            Actual.ShouldEqual(Expected);
+        }
+    }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
+    public class when_parsing_an_enum_value_null_defaultValue_null : TypeParserTestsContext
+    {
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void enum_value_is_returned()
+        {
+            Parser.Parse(typeof(Formatting), null, null);
+        }
+    }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
+    public class when_parsing_an_enum_value_null : TypeParserTestsContext
+    {
+        public override void When()
+        {
+            Expected = (Formatting)0;
+            Actual = Parser.Parse(typeof(Formatting), null);
         }
 
         [TestMethod]
@@ -252,6 +298,24 @@ namespace Microsoft.Qwiq
 
     [TestClass]
     // ReSharper disable once InconsistentNaming
+    public class when_parsing_an_empty_string_nonnullable_double_and_null_defaultvalue : TypeParserFirstChanceExceptionContext
+    {
+        public override void When()
+        {
+            Expected = 0d;
+            Actual = Parser.Parse(typeof(double), "", null);
+        }
+
+        [TestMethod]
+        public void default_value_is_returned_without_exception()
+        {
+            Actual.ShouldEqual(Expected);
+            FirstChanceException.ShouldBeNull();
+        }
+    }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
     public class when_parsing_an_empty_string_nonnullable_uint : TypeParserFirstChanceExceptionContext
     {
         public override void When()
@@ -383,6 +447,24 @@ namespace Microsoft.Qwiq
         public override void When()
         {
             Expected = DateTime.MinValue;
+            Actual = (DateTime)Parser.Parse(typeof(DateTime), (object)"");
+        }
+
+        [TestMethod]
+        public void default_value_is_returned_without_exception()
+        {
+            Actual.ShouldEqual(Expected);
+            FirstChanceException.ShouldBeNull();
+        }
+    }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
+    public class when_parsing_an_empty_string_nonnullable_DateTime_Generic : TypeParserFirstChanceExceptionContext
+    {
+        public override void When()
+        {
+            Expected = DateTime.MinValue;
             Actual = Parser.Parse<DateTime>("");
         }
 
@@ -391,6 +473,18 @@ namespace Microsoft.Qwiq
         {
             Actual.ShouldEqual(Expected);
             FirstChanceException.ShouldBeNull();
+        }
+    }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
+    public class when_parsing_a_valid_nonnullable_double_with_nuill_for_value_and_defaultvalue : TypeParserTestsContext
+    {
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void value_is_parsed_as_double()
+        {
+            Parser.Parse(typeof(double), null, null);
         }
     }
 
@@ -423,6 +517,40 @@ namespace Microsoft.Qwiq
 
         [TestMethod]
         public void value_is_null()
+        {
+            Actual.ShouldEqual(Expected);
+        }
+    }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
+    public class when_parsing_a_byte_to_decimal : TypeParserTestsContext
+    {
+        public override void When()
+        {
+            Expected = (decimal)255;
+            Actual = Parser.Parse(typeof(decimal), (object)((byte)255));
+        }
+
+        [TestMethod]
+        public void decimal_value_is_expected()
+        {
+            Actual.ShouldEqual(Expected);
+        }
+    }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
+    public class when_parsing_a_null_nullable_double_with_defaultValue_of_decimal : TypeParserTestsContext
+    {
+        public override void When()
+        {
+            Expected = 1.0M;
+            Actual = Parser.Parse(typeof(double?), null, 1.0M);
+        }
+
+        [TestMethod]
+        public void value_is_defaultValue()
         {
             Actual.ShouldEqual(Expected);
         }

--- a/test/Qwiq.Core.Tests/TypeParser/TypeParserTests.cs
+++ b/test/Qwiq.Core.Tests/TypeParser/TypeParserTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Xml;
-
+using JetBrains.Annotations;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Should;
@@ -144,18 +144,253 @@ namespace Microsoft.Qwiq
 
     [TestClass]
     // ReSharper disable once InconsistentNaming
-    public class when_parsing_an_empty_string_nonnullable_double : TypeParserTestsContext
+    public class when_parsing_an_empty_string_nonnullable_bool : TypeParserFirstChanceExceptionContext
     {
         public override void When()
         {
-            Expected = 11d;
-            Actual = Parser.Parse<double>("", 11);
+            Expected = false;
+            Actual = Parser.Parse<bool>("");
         }
 
         [TestMethod]
-        public void default_value_is_returned()
+        public void default_value_is_returned_without_exception()
         {
             Actual.ShouldEqual(Expected);
+            FirstChanceException.ShouldBeNull();
+        }
+    }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
+    public class when_parsing_an_empty_string_nonnullable_SByte : TypeParserFirstChanceExceptionContext
+    {
+        public override void When()
+        {
+            Expected = (sbyte)0;
+            Actual = Parser.Parse<sbyte>("");
+        }
+
+        [TestMethod]
+        public void default_value_is_returned_without_exception()
+        {
+            Actual.ShouldEqual(Expected);
+            FirstChanceException.ShouldBeNull();
+        }
+    }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
+    public class when_parsing_an_empty_string_nonnullable_byte : TypeParserFirstChanceExceptionContext
+    {
+        public override void When()
+        {
+            Expected = (byte)0;
+            Actual = Parser.Parse<byte>("");
+        }
+
+        [TestMethod]
+        public void default_value_is_returned_without_exception()
+        {
+            Actual.ShouldEqual(Expected);
+            FirstChanceException.ShouldBeNull();
+        }
+    }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
+    public class when_parsing_an_empty_string_nonnullable_short : TypeParserFirstChanceExceptionContext
+    {
+        public override void When()
+        {
+            Expected = (short)0;
+            Actual = Parser.Parse<short>("");
+        }
+
+        [TestMethod]
+        public void default_value_is_returned_without_exception()
+        {
+            Actual.ShouldEqual(Expected);
+            FirstChanceException.ShouldBeNull();
+        }
+    }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
+    public class when_parsing_an_empty_string_nonnullable_ushort : TypeParserFirstChanceExceptionContext
+    {
+        public override void When()
+        {
+            Expected = (ushort)0;
+            Actual = Parser.Parse<ushort>("");
+        }
+
+        [TestMethod]
+        public void default_value_is_returned_without_exception()
+        {
+            Actual.ShouldEqual(Expected);
+            FirstChanceException.ShouldBeNull();
+        }
+    }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
+    public class when_parsing_an_empty_string_nonnullable_double : TypeParserFirstChanceExceptionContext
+    {
+        public override void When()
+        {
+            Expected = 0d;
+            Actual = Parser.Parse<double>("");
+        }
+
+        [TestMethod]
+        public void default_value_is_returned_without_exception()
+        {
+            Actual.ShouldEqual(Expected);
+            FirstChanceException.ShouldBeNull();
+        }
+    }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
+    public class when_parsing_an_empty_string_nonnullable_uint : TypeParserFirstChanceExceptionContext
+    {
+        public override void When()
+        {
+            Expected = (uint)0;
+            Actual = Parser.Parse<uint>("");
+        }
+
+        [TestMethod]
+        public void default_value_is_returned_without_exception()
+        {
+            Actual.ShouldEqual(Expected);
+            FirstChanceException.ShouldBeNull();
+        }
+    }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
+    public class when_parsing_an_empty_string_nonnullable_int : TypeParserFirstChanceExceptionContext
+    {
+        public override void When()
+        {
+            Expected = 0;
+            Actual = Parser.Parse<int>("");
+        }
+
+        [TestMethod]
+        public void default_value_is_returned_without_exception()
+        {
+            Actual.ShouldEqual(Expected);
+            FirstChanceException.ShouldBeNull();
+        }
+    }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
+    public class when_parsing_an_empty_string_string : TypeParserFirstChanceExceptionContext
+    {
+        public override void When()
+        {
+            Expected = string.Empty;
+            Actual = Parser.Parse<string>("");
+        }
+
+        [TestMethod]
+        public void default_value_is_returned_without_exception()
+        {
+            Actual.ShouldEqual(Expected);
+            FirstChanceException.ShouldBeNull();
+        }
+    }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
+    public class when_parsing_an_empty_string_nonnullable_long : TypeParserFirstChanceExceptionContext
+    {
+        public override void When()
+        {
+            Expected = 0L;
+            Actual = Parser.Parse<long>("");
+        }
+
+        [TestMethod]
+        public void default_value_is_returned_without_exception()
+        {
+            Actual.ShouldEqual(Expected);
+            FirstChanceException.ShouldBeNull();
+        }
+    }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
+    public class when_parsing_an_empty_string_nonnullable_ulong : TypeParserFirstChanceExceptionContext
+    {
+        public override void When()
+        {
+            Expected = (ulong)0;
+            Actual = Parser.Parse<ulong>("");
+        }
+
+        [TestMethod]
+        public void default_value_is_returned_without_exception()
+        {
+            Actual.ShouldEqual(Expected);
+            FirstChanceException.ShouldBeNull();
+        }
+    }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
+    public class when_parsing_an_empty_string_nonnullable_float : TypeParserFirstChanceExceptionContext
+    {
+        public override void When()
+        {
+            Expected = (float)0;
+            Actual = Parser.Parse<float>("");
+        }
+
+        [TestMethod]
+        public void default_value_is_returned_without_exception()
+        {
+            Actual.ShouldEqual(Expected);
+            FirstChanceException.ShouldBeNull();
+        }
+    }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
+    public class when_parsing_an_empty_string_nonnullable_decimal : TypeParserFirstChanceExceptionContext
+    {
+        public override void When()
+        {
+            Expected = (decimal)0;
+            Actual = Parser.Parse<decimal>("");
+        }
+
+        [TestMethod]
+        public void default_value_is_returned_without_exception()
+        {
+            Actual.ShouldEqual(Expected);
+            FirstChanceException.ShouldBeNull();
+        }
+    }
+
+    [TestClass]
+    // ReSharper disable once InconsistentNaming
+    public class when_parsing_an_empty_string_nonnullable_DateTime : TypeParserFirstChanceExceptionContext
+    {
+        public override void When()
+        {
+            Expected = DateTime.MinValue;
+            Actual = Parser.Parse<DateTime>("");
+        }
+
+        [TestMethod]
+        public void default_value_is_returned_without_exception()
+        {
+            Actual.ShouldEqual(Expected);
+            FirstChanceException.ShouldBeNull();
         }
     }
 

--- a/test/Qwiq.Mapper.Benchmark.Tests/PocoMapping.cs
+++ b/test/Qwiq.Mapper.Benchmark.Tests/PocoMapping.cs
@@ -44,9 +44,8 @@ namespace Microsoft.Qwiq.Mapper.Benchmark.Tests
             public void SetupData()
             {
                 var propertyInspector = new PropertyInspector(new PropertyReflector());
-                var typeParser = TypeParser.Default;
                 var mappingStrategies = new IWorkItemMapperStrategy[]
-                                            { new AttributeMapperStrategy(propertyInspector, typeParser) };
+                                            { new AttributeMapperStrategy(propertyInspector) };
                 _mapper = new WorkItemMapper(mappingStrategies);
 
                 var wis = new MockWorkItemStore();

--- a/test/Qwiq.Mapper.Benchmark.Tests/PocoMappingWithLinks.cs
+++ b/test/Qwiq.Mapper.Benchmark.Tests/PocoMappingWithLinks.cs
@@ -49,10 +49,9 @@ namespace Microsoft.Qwiq.Mapper.Benchmark.Tests
                                                                         new[] { "Revisions", "Item" });
                 wis.Add(generator.Generate());
                 var propertyInspector = new PropertyInspector(new PropertyReflector());
-                var typeParser = TypeParser.Default;
                 var mappingStrategies = new IWorkItemMapperStrategy[]
                                             {
-                                                new AttributeMapperStrategy(propertyInspector, typeParser),
+                                                new AttributeMapperStrategy(propertyInspector),
                                                 new WorkItemLinksMapperStrategy(propertyInspector, wis),
                                             };
                 _mapper = new WorkItemMapper(mappingStrategies);

--- a/test/Qwiq.Mapper.Tests/GlobalSuppressions.cs
+++ b/test/Qwiq.Mapper.Tests/GlobalSuppressions.cs
@@ -1,0 +1,10 @@
+﻿
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CC0022:Should dispose object", Justification = "<Pending>", Scope = "member", Target = "~M:Microsoft.Qwiq.Mapper.Foo.Given")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CC0022:Should dispose object", Justification = "<Pending>", Scope = "member", Target = "~M:Microsoft.Qwiq.Mapper.Given_a_model_with_a_field_of_type_Double_mapped_from_StringEmpty_with_NullSub.Given")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CC0022:Should dispose object", Justification = "<Pending>", Scope = "member", Target = "~M:Microsoft.Qwiq.Mapper.Given_a_model_with_a_field_of_type_Double_mapped_from_StringEmpty.Given")]
+

--- a/test/Qwiq.Mapper.Tests/Linq/QueryableContextSpecification.cs
+++ b/test/Qwiq.Mapper.Tests/Linq/QueryableContextSpecification.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Qwiq.Mapper.Linq
 
             var mapperStrategies = new IWorkItemMapperStrategy[]
             {
-                new AttributeMapperStrategy(propertyInspector, TypeParser.Default),
+                new AttributeMapperStrategy(propertyInspector),
                 new WorkItemLinksMapperStrategy(propertyInspector, workItemStore)
             };
 

--- a/test/Qwiq.Mapper.Tests/Qwiq.Mapper.UnitTests.csproj
+++ b/test/Qwiq.Mapper.Tests/Qwiq.Mapper.UnitTests.csproj
@@ -55,6 +55,7 @@
       <Link>Properties\AssemblyInfo.Common.cs</Link>
     </Compile>
     <Compile Include="GenericQueryBuilderContextSpecification.cs" />
+    <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Linq\QueryableContextSpecification.cs" />
     <Compile Include="Mocks\InstrumentedMockQueryProvider.cs" />
     <Compile Include="Mocks\InstrumentedMockWorkItemStore.cs" />

--- a/test/Qwiq.Mapper.Tests/WorkItemMapperTests.cs
+++ b/test/Qwiq.Mapper.Tests/WorkItemMapperTests.cs
@@ -50,6 +50,10 @@ namespace Microsoft.Qwiq.Mapper
             {
                 "StringField",
                 "sample"
+            },
+            {
+                "EmptyStringField",
+                string.Empty
             }
         };
 
@@ -64,10 +68,9 @@ namespace Microsoft.Qwiq.Mapper
         public override void Given()
         {
             var propertyInspector = new PropertyInspector(new PropertyReflector());
-            var typeParser = TypeParser.Default;
             var mappingStrategies = new IWorkItemMapperStrategy[]
                                         {
-                                            new AttributeMapperStrategy(propertyInspector, typeParser),
+                                            new AttributeMapperStrategy(propertyInspector),
                                             new WorkItemLinksMapperStrategy(propertyInspector, WorkItemStore)
                                         };
             _workItemMapper = new WorkItemMapper(mappingStrategies);
@@ -81,6 +84,114 @@ namespace Microsoft.Qwiq.Mapper
         public override void Cleanup()
         {
             WorkItemStore?.Dispose();
+        }
+    }
+
+    [TestClass]
+    public class Given_a_model_with_a_field_of_type_Double_mapped_from_StringEmpty_Requiring_Conversion : WorkItemMapperContext<Given_a_model_with_a_field_of_type_Double_mapped_from_StringEmpty_Requiring_Conversion.EmptyStringModel>
+    {
+        public override void Given()
+        {
+            SourceWorkItems = new[] { new MockWorkItem(new MockWorkItemType("EmptyStringField", WorkItemBackingStore.Keys.Select(MockFieldDefinition.Create)), WorkItemBackingStore) };
+            WorkItemStore = new MockWorkItemStore().Add(SourceWorkItems);
+            base.Given();
+        }
+
+        [TestMethod]
+        public void the_mapped_property_is_the_substituted_value()
+        {
+            Actual.DoubleField.ShouldEqual(0.0d);
+        }
+
+        [WorkItemType("EmptyStringField")]
+        public class EmptyStringModel : IIdentifiable<int?>
+        {
+            [FieldDefinition("Id")]
+            public int? Id { get;set;}
+
+            [FieldDefinition("EmptyStringField", true)]
+            public double DoubleField { get;set;}
+        }
+    }
+
+    [TestClass]
+    public class Given_a_model_with_a_field_of_type_Double_mapped_from_StringEmpty_with_NullSub : WorkItemMapperContext<Given_a_model_with_a_field_of_type_Double_mapped_from_StringEmpty_Requiring_Conversion.EmptyStringModel>
+    {
+        public override void Given()
+        {
+            SourceWorkItems = new[] { new MockWorkItem(new MockWorkItemType("EmptyStringField", WorkItemBackingStore.Keys.Select(MockFieldDefinition.Create)), WorkItemBackingStore) };
+            WorkItemStore = new MockWorkItemStore().Add(SourceWorkItems);
+            base.Given();
+        }
+
+        [TestMethod]
+        public void the_mapped_property_is_the_substituted_value()
+        {
+            Actual.DoubleField.ShouldEqual(0.0d);
+        }
+
+        [WorkItemType("EmptyStringField")]
+        public class EmptyStringModel : IIdentifiable<int?>
+        {
+            [FieldDefinition("Id")]
+            public int? Id { get; set; }
+
+            [FieldDefinition("EmptyStringField", 0.0d)]
+            public double DoubleField { get; set; }
+        }
+    }
+
+    [TestClass]
+    public class Given_a_model_with_a_field_of_type_Double_mapped_from_StringEmpty : WorkItemMapperContext<Given_a_model_with_a_field_of_type_Double_mapped_from_StringEmpty.EmptyStringModel>
+    {
+        public override void Given()
+        {
+            SourceWorkItems = new[] { new MockWorkItem(new MockWorkItemType("EmptyStringField", WorkItemBackingStore.Keys.Select(MockFieldDefinition.Create)), WorkItemBackingStore) };
+            WorkItemStore = new MockWorkItemStore().Add(SourceWorkItems);
+            base.Given();
+        }
+
+        [TestMethod]
+        public void the_mapped_property_is_the_substituted_value()
+        {
+            Actual.DoubleField.ShouldEqual(0.0d);
+        }
+
+        [WorkItemType("EmptyStringField")]
+        public class EmptyStringModel : IIdentifiable<int?>
+        {
+            [FieldDefinition("Id")]
+            public int? Id { get; set; }
+
+            [FieldDefinition("EmptyStringField")]
+            public double DoubleField { get; set; }
+        }
+    }
+
+    [TestClass]
+    public class Given_a_model_with_a_field_of_type_Double_mapped_from_StringEmpty_Requiring_Conversion_with_Default : WorkItemMapperContext<Given_a_model_with_a_field_of_type_Double_mapped_from_StringEmpty_Requiring_Conversion_with_Default.EmptyStringModel>
+    {
+        public override void Given()
+        {
+            SourceWorkItems = new[] { new MockWorkItem(new MockWorkItemType("EmptyStringField", WorkItemBackingStore.Keys.Select(MockFieldDefinition.Create)), WorkItemBackingStore) };
+            WorkItemStore = new MockWorkItemStore().Add(SourceWorkItems);
+            base.Given();
+        }
+
+        [TestMethod]
+        public void the_mapped_property_is_the_substituted_value()
+        {
+            Actual.DoubleField.ShouldEqual(0.0d);
+        }
+
+        [WorkItemType("EmptyStringField")]
+        public class EmptyStringModel : IIdentifiable<int?>
+        {
+            [FieldDefinition("Id")]
+            public int? Id { get; set; }
+
+            [FieldDefinition("EmptyStringField", true, 0.0d)]
+            public double DoubleField { get; set; }
         }
     }
 


### PR DESCRIPTION
Proposed changes:
 - Add JetBrains.Annotations for `ITypeParser`
 - Prevent first chance exceptions while parsing some types

In `TypeParser`, implementations of `object ParseImpl(Type, object)` and `object ParseImpl(Type, object, object)` now get the underlying type code (`TypeCode`) for the destination type and perform special checks against the value to be converted:
 - If the type code is one that is known to not accept an empty string, and
 - the value to be converted is an empty string, 

When both cases are satisfied, then either get the default value of the destination type or return the supplied default value.

+semver: patch