### PR TITLE
When building attribute cache, use field for WIT name

### DIFF
--- a/src/Qwiq.Mapper/Attributes/AttributeMapperStrategy.cs
+++ b/src/Qwiq.Mapper/Attributes/AttributeMapperStrategy.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Qwiq.Mapper.Attributes
         {
             // Composite key: work item type and target type
 
-            var workItemType = workItem.Type.Name;
+            var workItemType = workItem.WorkItemType;
             var key = new Tuple<string, RuntimeTypeHandle>(workItemType, targetType.TypeHandle);
 
             return PropertiesThatExistOnWorkItem.GetOrAdd(

--- a/src/Qwiq.Mapper/Attributes/WorkItemLinksMapperStrategy.cs
+++ b/src/Qwiq.Mapper/Attributes/WorkItemLinksMapperStrategy.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Qwiq.Mapper.Attributes
         {
             // Composite key: work item type and target type
 
-            var workItemType = workItem.Type.Name;
+            var workItemType = workItem.WorkItemType;
             var key = new Tuple<string, RuntimeTypeHandle>(workItemType, targetType.TypeHandle);
 
             return PropertiesThatExistOnWorkItem.GetOrAdd(


### PR DESCRIPTION
The new `IWorkItem` interface has a property named `WorkItemType`, which contains the name of the work item type for that work item. This is equivalent to the property `IWorkItem.Type.Name`, except that the work item store does not receive a query to load WIT meta data for just the name.