### PR TITLE
Provide better error message when unexpected values encountered for WIT

### DIFF
--- a/src/Qwiq.Core.Rest/WorkItem.cs
+++ b/src/Qwiq.Core.Rest/WorkItem.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Linq;
 
@@ -143,6 +144,9 @@ namespace Microsoft.Qwiq.Client.Rest
             if (string.IsNullOrEmpty(name)) return null;
 
             _item.Fields.TryGetValue(name, out object value);
+#if DEBUG
+            Trace.WriteLine($"Get \'{name}\': {value.ToUsefulString()}");
+#endif
             return value;
         }
 
@@ -151,6 +155,9 @@ namespace Microsoft.Qwiq.Client.Rest
             if (string.IsNullOrEmpty(name)) return;
 
             _item.Fields[name] = value;
+#if DEBUG
+            Trace.WriteLine($"Set \'{name}\' to {value.ToUsefulString()}");
+#endif
         }
 
         [ContractInvariantMethod]

--- a/src/Qwiq.Core/WorkItem.cs
+++ b/src/Qwiq.Core/WorkItem.cs
@@ -27,19 +27,19 @@ namespace Microsoft.Qwiq
 
         private bool _useFields = true;
 
-        protected internal WorkItem([NotNull] IWorkItemType type, [CanBeNull] Dictionary<string, object> fields)
+        protected internal WorkItem([NotNull] IWorkItemType workItemType, [CanBeNull] Dictionary<string, object> fields)
             : base(fields)
         {
-            Contract.Requires(type != null);
+            Contract.Requires(workItemType != null);
 
-            _type = type ?? throw new ArgumentNullException(nameof(type));
+            _type = workItemType ?? throw new ArgumentNullException(nameof(workItemType));
         }
 
-        protected internal WorkItem([NotNull] IWorkItemType type)
+        protected internal WorkItem([NotNull] IWorkItemType workItemType)
         {
-            Contract.Requires(type != null);
+            Contract.Requires(workItemType != null);
 
-            _type = type ?? throw new ArgumentNullException(nameof(type));
+            _type = workItemType ?? throw new ArgumentNullException(nameof(workItemType));
         }
 
         protected internal WorkItem([NotNull] Lazy<IWorkItemType> type)
@@ -48,11 +48,11 @@ namespace Microsoft.Qwiq
             _lazyType = type;
         }
 
-        protected internal WorkItem([NotNull] IWorkItemType type, [NotNull] Func<IFieldCollection> fieldCollectionFactory)
+        protected internal WorkItem([NotNull] IWorkItemType workItemType, [NotNull] Func<IFieldCollection> fieldCollectionFactory)
         {
-            Contract.Requires(type != null);
+            Contract.Requires(workItemType != null);
             Contract.Requires(fieldCollectionFactory != null);
-            _type = type ?? throw new ArgumentNullException(nameof(type));
+            _type = workItemType ?? throw new ArgumentNullException(nameof(workItemType));
             _fieldFactory = fieldCollectionFactory ?? throw new ArgumentNullException(nameof(fieldCollectionFactory));
         }
 
@@ -110,7 +110,7 @@ namespace Microsoft.Qwiq
 
         public virtual IEnumerable<IRevision> Revisions => throw new NotSupportedException();
 
-        public virtual IWorkItemType Type => _type ?? _lazyType?.Value ?? throw new NotSupportedException();
+        public virtual IWorkItemType Type => _type ?? _lazyType?.Value ?? throw new InvalidOperationException($"No value specified for {nameof(Type)}.");
 
         public abstract Uri Uri { get; }
 

--- a/src/Qwiq.Core/WorkItem.cs
+++ b/src/Qwiq.Core/WorkItem.cs
@@ -124,6 +124,10 @@ namespace Microsoft.Qwiq
                     {
                         return Fields[name].Value;
                     }
+                    catch (InvalidOperationException ioex) when (ioex.Source == "Microsoft.Qwiq.Client.Rest")
+                    {
+                        _useFields = false;
+                    }
                     catch (NotSupportedException)
                     {
                         _useFields = false;

--- a/src/Qwiq.Mapper/Attributes/AttributeMapperStrategy.cs
+++ b/src/Qwiq.Mapper/Attributes/AttributeMapperStrategy.cs
@@ -156,9 +156,9 @@ namespace Microsoft.Qwiq.Mapper.Attributes
                                          property =>
                                          new { property, fieldName = PropertyInfoFieldCache(inspector, property)?.FieldName })
                                      .Where(
-                                         @t =>
-                                         !string.IsNullOrEmpty(@t.fieldName) && workItem.Fields.Contains(@t.fieldName))
-                                     .Select(@t => @t.property)
+                                         t =>
+                                         !string.IsNullOrEmpty(t.fieldName))
+                                     .Select(t => t.property)
                                      .ToList();
                     });
         }

--- a/test/Qwiq.Integration.Tests/Mapper/AttributeMapperTests.cs
+++ b/test/Qwiq.Integration.Tests/Mapper/AttributeMapperTests.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Should;
+using System;
+using System.Linq;
 
 namespace Microsoft.Qwiq.Mapper
 {
@@ -13,8 +13,7 @@ namespace Microsoft.Qwiq.Mapper
         [TestMethod]
         [TestCategory("localOnly")]
         [TestCategory("REST")]
-        [ExpectedException(typeof(InvalidOperationException))]
-        public void An_InvalidOperationException_is_thrown()
+        public void The_work_items_are_mapped_to_their_model()
         {
             Bugs.ToList().Count.ShouldEqual(1);
         }
@@ -33,14 +32,34 @@ namespace Microsoft.Qwiq.Mapper
 
     [TestClass]
     public class
+        Given_an_AttributeMapper_with_a_WorkItemStore_DefaultFields_without_TeamProject_and_WorkItemType_specified_Eager :
+            Given_an_AttributeMapper_with_a_WorkItemStore_DefaultFields_without_TeamProject_and_WorkItemType_specified
+    {
+        [TestMethod]
+        [TestCategory("localOnly")]
+        [TestCategory("REST")]
+        [ExpectedException(typeof(InvalidOperationException), "The fields '" + CoreFieldRefNames.TeamProject + "' and '" + CoreFieldRefNames.WorkItemType + "' are required to load the Type property.")]
+        public new void The_work_items_are_mapped_to_their_model()
+        {
+            Bugs.ToList().Count.ShouldEqual(1);
+        }
+
+        protected override void ConfigureOptions()
+        {
+            base.ConfigureOptions();
+            WorkItemStore.Configuration.LazyLoadingEnabled = false;
+        }
+    }
+
+    [TestClass]
+    public class
         Given_an_AttributeMapper_with_a_WorkItemStore_DefaultFields_without_WorkItemType_specified :
             WiqlAttributeMapperContextSpecification
     {
         [TestMethod]
         [TestCategory("localOnly")]
         [TestCategory("REST")]
-        [ExpectedException(typeof(InvalidOperationException))]
-        public void An_InvalidOperationException_is_thrown()
+        public void The_work_items_are_mapped_to_their_model()
         {
             Bugs.ToList().Count.ShouldEqual(1);
         }
@@ -56,25 +75,19 @@ namespace Microsoft.Qwiq.Mapper
             };
         }
     }
-
-    [TestClass]
-    public class
-        Given_an_AttributeMapper_with_a_WorkItemStore_DefaultFields_without_TeamProject_and_WorkItemType_specified_Eager :
-            Given_an_AttributeMapper_with_a_WorkItemStore_DefaultFields_without_TeamProject_and_WorkItemType_specified
-    {
-        protected override void ConfigureOptions()
-        {
-            base.ConfigureOptions();
-            WorkItemStore.Configuration.LazyLoadingEnabled = false;
-        }
-    }
-
     [TestClass]
     public class
         Given_an_AttributeMapper_with_a_WorkItemStore_DefaultFields_without_WorkItemType_specified_Eager :
             Given_an_AttributeMapper_with_a_WorkItemStore_DefaultFields_without_WorkItemType_specified
     {
-
+        [TestMethod]
+        [TestCategory("localOnly")]
+        [TestCategory("REST")]
+        [ExpectedException(typeof(InvalidOperationException), "The fields '" + CoreFieldRefNames.TeamProject + "' and '" + CoreFieldRefNames.WorkItemType + "' are required to load the Type property.")]
+        public new void The_work_items_are_mapped_to_their_model()
+        {
+            Bugs.ToList().Count.ShouldEqual(1);
+        }
 
         protected override void ConfigureOptions()
         {

--- a/test/Qwiq.Integration.Tests/Mapper/AttributeMapperTests.cs
+++ b/test/Qwiq.Integration.Tests/Mapper/AttributeMapperTests.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Should;
+
+namespace Microsoft.Qwiq.Mapper
+{
+    [TestClass]
+    public class
+        Given_an_AttributeMapper_with_a_WorkItemStore_DefaultFields_without_TeamProject_and_WorkItemType_specified :
+            WiqlAttributeMapperContextSpecification
+    {
+        [TestMethod]
+        [TestCategory("localOnly")]
+        [TestCategory("REST")]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void An_InvalidOperationException_is_thrown()
+        {
+            Bugs.ToList().Count.ShouldEqual(1);
+        }
+
+        protected override void ConfigureOptions()
+        {
+            WorkItemStore.Configuration.DefaultFields = new[]
+            {
+                //CoreFieldRefNames.TeamProject,
+                //CoreFieldRefNames.WorkItemType,
+                CoreFieldRefNames.Id,
+                CoreFieldRefNames.State
+            };
+        }
+    }
+
+    [TestClass]
+    public class
+        Given_an_AttributeMapper_with_a_WorkItemStore_DefaultFields_without_WorkItemType_specified :
+            WiqlAttributeMapperContextSpecification
+    {
+        [TestMethod]
+        [TestCategory("localOnly")]
+        [TestCategory("REST")]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void An_InvalidOperationException_is_thrown()
+        {
+            Bugs.ToList().Count.ShouldEqual(1);
+        }
+
+        protected override void ConfigureOptions()
+        {
+            WorkItemStore.Configuration.DefaultFields = new[]
+            {
+                CoreFieldRefNames.TeamProject,
+                //CoreFieldRefNames.WorkItemType,
+                CoreFieldRefNames.Id,
+                CoreFieldRefNames.State
+            };
+        }
+    }
+
+    [TestClass]
+    public class
+        Given_an_AttributeMapper_with_a_WorkItemStore_DefaultFields_without_TeamProject_and_WorkItemType_specified_Eager :
+            Given_an_AttributeMapper_with_a_WorkItemStore_DefaultFields_without_TeamProject_and_WorkItemType_specified
+    {
+        protected override void ConfigureOptions()
+        {
+            base.ConfigureOptions();
+            WorkItemStore.Configuration.LazyLoadingEnabled = false;
+        }
+    }
+
+    [TestClass]
+    public class
+        Given_an_AttributeMapper_with_a_WorkItemStore_DefaultFields_without_WorkItemType_specified_Eager :
+            Given_an_AttributeMapper_with_a_WorkItemStore_DefaultFields_without_WorkItemType_specified
+    {
+
+
+        protected override void ConfigureOptions()
+        {
+            base.ConfigureOptions();
+            WorkItemStore.Configuration.LazyLoadingEnabled = false;
+        }
+    }
+}

--- a/test/Qwiq.Integration.Tests/Mapper/WiqlAttributeMapperContextSpecification.cs
+++ b/test/Qwiq.Integration.Tests/Mapper/WiqlAttributeMapperContextSpecification.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.Qwiq.Linq;
+using Microsoft.Qwiq.Linq.Visitors;
+using Microsoft.Qwiq.Mapper.Attributes;
+using Microsoft.Qwiq.Tests.Common;
+using System.Linq;
+
+namespace Microsoft.Qwiq.Mapper
+{
+    public abstract class WiqlAttributeMapperContextSpecification : TimedContextSpecification
+    {
+        private int[] _ids;
+        public IQueryable<Bug> Bugs { get; set; }
+        protected IWorkItemStore WorkItemStore { get; private set; }
+        private Query<Bug> Query { get; set; }
+        public override void Cleanup()
+        {
+            WorkItemStore?.Dispose();
+            base.Cleanup();
+        }
+
+        public override void Given()
+        {
+            base.Given();
+
+            WorkItemStore = TimedAction(() => IntegrationSettings.CreateRestStore(), "REST", "WIS Create");
+
+            ConfigureOptions();
+
+            var pr = new PropertyReflector();
+            var pi = new PropertyInspector(pr);
+            var attMapper = new AttributeMapperStrategy(pi);
+            var mapper = new WorkItemMapper(new IWorkItemMapperStrategy[] { attMapper });
+            var translator = new WiqlTranslator();
+            var pe = new PartialEvaluator();
+            var qr = new QueryRewriter();
+            var wqb = new WiqlQueryBuilder(translator, pe, qr);
+            var qp = new MapperTeamFoundationServerWorkItemQueryProvider(
+                WorkItemStore,
+                wqb,
+                mapper);
+
+            Query = new Query<Bug>(qp, wqb);
+
+            _ids = new[]
+            {
+                8663955
+            };
+        }
+
+        public override void When()
+        {
+            Bugs = Query.Where(b => _ids.Contains(b.Id.Value));
+        }
+
+        protected abstract void ConfigureOptions();
+        [WorkItemType("Bug")]
+        public class Bug : IIdentifiable<int?>
+        {
+            [FieldDefinition(CoreFieldRefNames.Id, true)]
+            public int? Id { get; set; }
+
+            [FieldDefinition(CoreFieldRefNames.State)]
+            public string State { get; set; }
+        }
+    }
+}

--- a/test/Qwiq.Integration.Tests/Mapper/WiqlAttributeMapperContextSpecification.cs
+++ b/test/Qwiq.Integration.Tests/Mapper/WiqlAttributeMapperContextSpecification.cs
@@ -61,6 +61,9 @@ namespace Microsoft.Qwiq.Mapper
 
             [FieldDefinition(CoreFieldRefNames.State)]
             public string State { get; set; }
+
+            [FieldDefinition("InvalidField")]
+            public string Invalid { get; set; }
         }
     }
 }

--- a/test/Qwiq.Integration.Tests/Qwiq.IntegrationTests.csproj
+++ b/test/Qwiq.Integration.Tests/Qwiq.IntegrationTests.csproj
@@ -195,6 +195,8 @@
     <Compile Include="Identity\Soap\SoapIdentityMapperContextSpecification.cs" />
     <Compile Include="IntegrationSettings.cs" />
     <Compile Include="Linq\LinqContextSpecification.cs" />
+    <Compile Include="Mapper\AttributeMapperTests.cs" />
+    <Compile Include="Mapper\WiqlAttributeMapperContextSpecification.cs" />
     <Compile Include="Mapper\Identity\DisplayNameToAliasConverterContextSpecification.cs" />
     <Compile Include="Mapper\Identity\DisplayNameToAliasConverterTests.cs" />
     <Compile Include="Mapper\Identity\MultipleDisplayNameContextSpecification.cs" />
@@ -263,6 +265,10 @@
     <ProjectReference Include="..\..\src\Qwiq.Mapper.Identity\Qwiq.Mapper.Identity.csproj">
       <Project>{BE25CF2D-FA53-4455-85B1-4EEC1D979FB1}</Project>
       <Name>Qwiq.Mapper.Identity</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Qwiq.Mapper\Qwiq.Mapper.csproj">
+      <Project>{016E8D93-4195-4639-BCD5-77633E8E1681}</Project>
+      <Name>Qwiq.Mapper</Name>
     </ProjectReference>
     <ProjectReference Include="..\Qwiq.Tests.Common\Qwiq.Tests.Common.csproj">
       <Project>{B45C92B0-AC36-409D-86A5-5428C87384C3}</Project>

--- a/test/Qwiq.Mocks/MockWorkItem.cs
+++ b/test/Qwiq.Mocks/MockWorkItem.cs
@@ -82,31 +82,31 @@ namespace Microsoft.Qwiq.Mocks
             }
         }
 
-        public MockWorkItem([NotNull] IWorkItemType type, int id)
-            : this(type, new KeyValuePair<string, object>(CoreFieldRefNames.Id, id))
+        public MockWorkItem([NotNull] IWorkItemType workItemType, int id)
+            : this(workItemType, new KeyValuePair<string, object>(CoreFieldRefNames.Id, id))
         {
             Contract.Requires(id > 0);
         }
 
-        public MockWorkItem([NotNull] IWorkItemType type, int id, [CanBeNull] params KeyValuePair<string, object>[] fieldValues)
+        public MockWorkItem([NotNull] IWorkItemType workItemType, int id, [CanBeNull] params KeyValuePair<string, object>[] fieldValues)
             : this(
-                   type,
+                   workItemType,
                    fieldValues?.Union(new[] { new KeyValuePair<string, object>(CoreFieldRefNames.Id, id) })
                               .ToDictionary(k => k.Key, e => e.Value, StringComparer.OrdinalIgnoreCase) ?? new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase) { { CoreFieldRefNames.Id, id } })
         {
             Contract.Requires(id > 0);
         }
 
-        public MockWorkItem([NotNull] IWorkItemType type, [CanBeNull] params KeyValuePair<string, object>[] fieldValues)
-            : this(type, fieldValues?.ToDictionary(k => k.Key, e => e.Value, StringComparer.OrdinalIgnoreCase))
+        public MockWorkItem([NotNull] IWorkItemType workItemType, [CanBeNull] params KeyValuePair<string, object>[] fieldValues)
+            : this(workItemType, fieldValues?.ToDictionary(k => k.Key, e => e.Value, StringComparer.OrdinalIgnoreCase))
         {
         }
 
-        public MockWorkItem([NotNull] IWorkItemType type, [CanBeNull] Dictionary<string, object> fields = null)
-            : base(type, NormalizeFields(type, fields))
+        public MockWorkItem([NotNull] IWorkItemType workItemType, [CanBeNull] Dictionary<string, object> fields = null)
+            : base(workItemType, NormalizeFields(workItemType, fields))
         {
-            SetFieldValue(type.FieldDefinitions[CoreFieldRefNames.WorkItemType], type.Name);
-            SetFieldValue(type.FieldDefinitions[CoreFieldRefNames.RevisedDate], new DateTime(9999, 1, 1, 0, 0, 0));
+            SetFieldValue(workItemType.FieldDefinitions[CoreFieldRefNames.WorkItemType], workItemType.Name);
+            SetFieldValue(workItemType.FieldDefinitions[CoreFieldRefNames.RevisedDate], new DateTime(9999, 1, 1, 0, 0, 0));
 
             if (IsNew)
             {


### PR DESCRIPTION
In order to load the `Type` property on `WorkItem`, the `System.TeamProject` and `System.WorkItemType` fields must have values. Additionally, checks are performed against the project and work item types collections to verify a project and WIT are present, avoiding another KeyNotFoundException at runtime. The changes are targeted to the REST client because the SOAP client will lazily retrieve the fields when asked whereas REST will not.

This change includes new integration tests to verify the functionality.