### PR TITLE
support identity membership

### DIFF
--- a/src/Qwiq.Identity.Soap/IdentityManagementService.cs
+++ b/src/Qwiq.Identity.Soap/IdentityManagementService.cs
@@ -24,20 +24,28 @@ namespace Microsoft.Qwiq.Identity.Soap
 
         public IEnumerable<ITeamFoundationIdentity> ReadIdentities(IEnumerable<IIdentityDescriptor> descriptors)
         {
+            return ReadIdentities(descriptors, MembershipQuery.None);
+        }
+
+        public IEnumerable<ITeamFoundationIdentity> ReadIdentities(
+            IEnumerable<IIdentityDescriptor> descriptors,
+            MembershipQuery queryMembership)
+        {
+            if (descriptors == null) throw new ArgumentNullException(nameof(descriptors));
+
             var rawDescriptors = descriptors.Select(
-                                                    descriptor => new TeamFoundation.Framework.Client.IdentityDescriptor(
-                                                                                                                         descriptor
-                                                                                                                                 .IdentityType,
-                                                                                                                         descriptor
-                                                                                                                                 .Identifier))
-                                            .ToArray();
+                    descriptor => new TeamFoundation.Framework.Client.IdentityDescriptor(
+                        descriptor.IdentityType,
+                        descriptor.Identifier))
+                .ToArray();
 
             var identities =
-                    _identityManagementService2.ReadIdentities(
-                                                               rawDescriptors,
-                                                               MembershipQuery.None,
-                                                               ReadIdentityOptions.IncludeReadFromSource);
+                _identityManagementService2.ReadIdentities(
+                    rawDescriptors,
+                    (TeamFoundation.Framework.Common.MembershipQuery)queryMembership,
+            ReadIdentityOptions.IncludeReadFromSource);
 
+            // TODO: Use configuration options from IWorkItemStore to control proxy creation
             return identities.Select(identity => identity?.AsProxy());
         }
 
@@ -45,33 +53,57 @@ namespace Microsoft.Qwiq.Identity.Soap
             IdentitySearchFactor searchFactor,
             IEnumerable<string> searchFactorValues)
         {
+            return ReadIdentities(searchFactor, searchFactorValues, MembershipQuery.None);
+        }
+
+        public IEnumerable<KeyValuePair<string, IEnumerable<ITeamFoundationIdentity>>> ReadIdentities(
+            IdentitySearchFactor searchFactor,
+            IEnumerable<string> searchFactorValues,
+            MembershipQuery queryMembership)
+        {
+            if (searchFactorValues == null) throw new ArgumentNullException(nameof(searchFactorValues));
+
             var searchFactorArray = searchFactorValues.ToArray();
             var factor = (TeamFoundation.Framework.Common.IdentitySearchFactor)searchFactor;
             var identities = _identityManagementService2.ReadIdentities(
-                                                                        factor,
-                                                                        searchFactorArray,
-                                                                        MembershipQuery.None,
-                                                                        ReadIdentityOptions.IncludeReadFromSource);
+                factor,
+                searchFactorArray,
+                (TeamFoundation.Framework.Common.MembershipQuery)queryMembership,
+                ReadIdentityOptions.IncludeReadFromSource);
 
             if (searchFactorArray.Length != identities.Length)
                 throw new IndexOutOfRangeException(
-                                                   "A call to IIdentityManagementService2.ReadIdentities resulted in a return set where there was not a one to one mapping between search terms and search results. This is unexpected behavior and execution cannot continue. Please check if the underlying service implementation has changed and update the consuming code as appropriate.");
+                    "A call to IIdentityManagementService2.ReadIdentities resulted in a return set where there was not a one to one mapping between search terms and search results. This is unexpected behavior and execution cannot continue. Please check if the underlying service implementation has changed and update the consuming code as appropriate.");
 
             for (var i = 0; i < searchFactorArray.Length; i++)
             {
-                var proxiedIdentities = identities[i].Select(id=>id.AsProxy());
+                // TODO: Use configuration options from IWorkItemStore to control proxy creation
+                var proxiedIdentities = identities[i].Select(id => id.AsProxy());
                 yield return new KeyValuePair<string, IEnumerable<ITeamFoundationIdentity>>(searchFactorArray[i], proxiedIdentities);
             }
         }
 
-        public ITeamFoundationIdentity ReadIdentity(IdentitySearchFactor searchFactor, string searchFactorValue)
+        public ITeamFoundationIdentity ReadIdentity(
+            IdentitySearchFactor searchFactor,
+            string searchFactorValue)
         {
-           return  _identityManagementService2.ReadIdentity(
-                                                     (TeamFoundation.Framework.Common.IdentitySearchFactor)searchFactor,
-                                                     searchFactorValue,
-                                                     MembershipQuery.None,
-                                                     ReadIdentityOptions.IncludeReadFromSource)
-                                                     .AsProxy();
+            return ReadIdentity(searchFactor, searchFactorValue, MembershipQuery.None);
+        }
+
+        public ITeamFoundationIdentity ReadIdentity(
+            IdentitySearchFactor searchFactor,
+            string searchFactorValue,
+            MembershipQuery queryMembership)
+        {
+            if (string.IsNullOrEmpty(searchFactorValue)) throw new ArgumentException("Value cannot be null or empty.", nameof(searchFactorValue));
+
+            // TODO: Use configuration options from IWorkItemStore to control proxy creation
+            return _identityManagementService2.ReadIdentity(
+                    (TeamFoundation.Framework.Common.IdentitySearchFactor)searchFactor,
+                    searchFactorValue,
+                    (TeamFoundation.Framework.Common.MembershipQuery)queryMembership,
+                    ReadIdentityOptions.IncludeReadFromSource)
+                .AsProxy();
         }
     }
 }

--- a/src/Qwiq.Identity/IIdentityManagementService.cs
+++ b/src/Qwiq.Identity/IIdentityManagementService.cs
@@ -20,6 +20,16 @@ namespace Microsoft.Qwiq.Identity
         IEnumerable<ITeamFoundationIdentity> ReadIdentities([NotNull] IEnumerable<IIdentityDescriptor> descriptors);
 
         /// <summary>
+        /// Read identities for given <paramref name="descriptors"/>.
+        /// </summary>
+        /// <param name="descriptors">A set of <see cref="IIdentityDescriptor"/>s</param>
+        /// <param name="queryMembership"></param>
+        /// <returns></returns>
+        [NotNull]
+        [Pure]
+        IEnumerable<ITeamFoundationIdentity> ReadIdentities([NotNull] IEnumerable<IIdentityDescriptor> descriptors, MembershipQuery queryMembership);
+
+        /// <summary>
         /// Read identities for given <paramref name="searchFactor"/> and <paramref name="searchFactorValues"/>.
         /// </summary>
         /// <param name="searchFactor">Specific search.</param>
@@ -31,8 +41,26 @@ namespace Microsoft.Qwiq.Identity
             IdentitySearchFactor searchFactor,
             [NotNull] IEnumerable<string> searchFactorValues);
 
+        /// <summary>
+        /// Read identities for given <paramref name="searchFactor"/> and <paramref name="searchFactorValues"/>.
+        /// </summary>
+        /// <param name="searchFactor">Specific search.</param>
+        /// <param name="searchFactorValues">Actual search strings.</param>
+        /// <param name="queryMembership"></param>
+        /// <returns>An enumerable set of identities corresponding 1 to 1 with <paramref name="searchFactorValues"/>.</returns>
+        [NotNull]
+        [Pure]
+        IEnumerable<KeyValuePair<string, IEnumerable<ITeamFoundationIdentity>>> ReadIdentities(
+            IdentitySearchFactor searchFactor,
+            [NotNull] IEnumerable<string> searchFactorValues,
+            MembershipQuery queryMembership);
+
         [CanBeNull]
         [Pure]
         ITeamFoundationIdentity ReadIdentity(IdentitySearchFactor searchFactor, [NotNull] string searchFactorValue);
+
+        [CanBeNull]
+        [Pure]
+        ITeamFoundationIdentity ReadIdentity(IdentitySearchFactor searchFactor, [NotNull] string searchFactorValue, MembershipQuery queryMembership);
     }
 }

--- a/src/Qwiq.Identity/MembershipQuery.cs
+++ b/src/Qwiq.Identity/MembershipQuery.cs
@@ -1,0 +1,29 @@
+namespace Microsoft.Qwiq.Identity
+{
+    /// <summary>
+    /// Indicates the method to populate <see cref="ITeamFoundationIdentity"/>
+    /// </summary>
+    public enum MembershipQuery
+    {
+        /// <summary>
+        /// Query will not return any membership data
+        /// </summary>
+        None = 0,
+        /// <summary>
+        ///     Query will return only direct membership data
+        /// </summary>
+        Direct = 1,
+        /// <summary>
+        ///     Query will return expanded membership data
+        /// </summary>
+        Expanded = 2,
+        /// <summary>
+        ///     Query will return expanded up membership data (parents only)
+        /// </summary>
+        ExpandedUp = 3,
+        /// <summary>
+        ///     Query will return expanded down membership data (children only)
+        /// </summary>
+        ExpandedDown = 4
+    }
+}

--- a/src/Qwiq.Identity/Qwiq.Identity.csproj
+++ b/src/Qwiq.Identity/Qwiq.Identity.csproj
@@ -37,6 +37,7 @@
     <Compile Include="IdentityValueConverterBase.cs" />
     <Compile Include="IIdentityManagementService.cs" />
     <Compile Include="IIdentityValueConverter.cs" />
+    <Compile Include="MembershipQuery.cs" />
     <Compile Include="MultipleIdentitiesFoundException.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/test/Qwiq.Identity.Tests/Mocks/MockIdentityManagementService2.cs
+++ b/test/Qwiq.Identity.Tests/Mocks/MockIdentityManagementService2.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Qwiq.Identity.Mocks
 
         public TeamFoundation.Framework.Client.TeamFoundationIdentity[] ReadIdentities(
             TeamFoundation.Framework.Client.IdentityDescriptor[] descriptors,
-            MembershipQuery queryMembership,
+            TeamFoundation.Framework.Common.MembershipQuery queryMembership,
             ReadIdentityOptions readOptions)
         {
             return NullIdentities;
@@ -115,7 +115,7 @@ namespace Microsoft.Qwiq.Identity.Mocks
 
         public TeamFoundation.Framework.Client.TeamFoundationIdentity[] ReadIdentities(
             Guid[] teamFoundationIds,
-            MembershipQuery queryMembership)
+            TeamFoundation.Framework.Common.MembershipQuery queryMembership)
         {
             return NullIdentities;
         }
@@ -123,7 +123,7 @@ namespace Microsoft.Qwiq.Identity.Mocks
         public TeamFoundation.Framework.Client.TeamFoundationIdentity[][] ReadIdentities(
             TeamFoundation.Framework.Common.IdentitySearchFactor searchFactor,
             string[] searchFactorValues,
-            MembershipQuery queryMembership,
+            TeamFoundation.Framework.Common.MembershipQuery queryMembership,
             ReadIdentityOptions readOptions)
         {
             return new[] { NullIdentities };
@@ -131,7 +131,7 @@ namespace Microsoft.Qwiq.Identity.Mocks
 
         public TeamFoundation.Framework.Client.TeamFoundationIdentity[] ReadIdentities(
             Guid[] teamFoundationIds,
-            MembershipQuery queryMembership,
+            TeamFoundation.Framework.Common.MembershipQuery queryMembership,
             ReadIdentityOptions readOptions,
             IEnumerable<string> propertyNameFilters,
             IdentityPropertyScope propertyScope)
@@ -142,7 +142,7 @@ namespace Microsoft.Qwiq.Identity.Mocks
         public TeamFoundation.Framework.Client.TeamFoundationIdentity[][] ReadIdentities(
             TeamFoundation.Framework.Common.IdentitySearchFactor searchFactor,
             string[] searchFactorValues,
-            MembershipQuery queryMembership,
+            TeamFoundation.Framework.Common.MembershipQuery queryMembership,
             ReadIdentityOptions readOptions,
             IEnumerable<string> propertyNameFilters,
             IdentityPropertyScope propertyScope)
@@ -152,7 +152,7 @@ namespace Microsoft.Qwiq.Identity.Mocks
 
         public TeamFoundation.Framework.Client.TeamFoundationIdentity[] ReadIdentities(
             TeamFoundation.Framework.Client.IdentityDescriptor[] descriptors,
-            MembershipQuery queryMembership,
+            TeamFoundation.Framework.Common.MembershipQuery queryMembership,
             ReadIdentityOptions readOptions,
             IEnumerable<string> propertyNameFilters,
             IdentityPropertyScope propertyScope)
@@ -163,7 +163,7 @@ namespace Microsoft.Qwiq.Identity.Mocks
         public TeamFoundation.Framework.Client.TeamFoundationIdentity ReadIdentity(
             TeamFoundation.Framework.Common.IdentitySearchFactor searchFactor,
             string searchFactorValue,
-            MembershipQuery queryMembership,
+            TeamFoundation.Framework.Common.MembershipQuery queryMembership,
             ReadIdentityOptions readOptions)
         {
             throw new NotImplementedException();
@@ -171,7 +171,7 @@ namespace Microsoft.Qwiq.Identity.Mocks
 
         public TeamFoundation.Framework.Client.TeamFoundationIdentity ReadIdentity(
             TeamFoundation.Framework.Client.IdentityDescriptor descriptor,
-            MembershipQuery queryMembership,
+            TeamFoundation.Framework.Common.MembershipQuery queryMembership,
             ReadIdentityOptions readOptions)
         {
             throw new NotSupportedException();
@@ -185,7 +185,7 @@ namespace Microsoft.Qwiq.Identity.Mocks
         public TeamFoundation.Framework.Client.TeamFoundationIdentity ReadIdentity(
             TeamFoundation.Framework.Common.IdentitySearchFactor searchFactor,
             string searchFactorValue,
-            MembershipQuery queryMembership,
+            TeamFoundation.Framework.Common.MembershipQuery queryMembership,
             ReadIdentityOptions readOptions,
             IEnumerable<string> propertyNameFilters,
             IdentityPropertyScope propertyScope)
@@ -195,7 +195,7 @@ namespace Microsoft.Qwiq.Identity.Mocks
 
         public TeamFoundation.Framework.Client.TeamFoundationIdentity ReadIdentity(
             TeamFoundation.Framework.Client.IdentityDescriptor descriptor,
-            MembershipQuery queryMembership,
+            TeamFoundation.Framework.Common.MembershipQuery queryMembership,
             ReadIdentityOptions readOptions,
             IEnumerable<string> propertyNameFilters,
             IdentityPropertyScope propertyScope)
@@ -241,7 +241,7 @@ namespace Microsoft.Qwiq.Identity.Mocks
         public TeamFoundation.Framework.Client.TeamFoundationIdentity[][] ReadIdentities(
             IdentitySearchFactor searchFactor,
             string[] searchFactorValues,
-            MembershipQuery queryMembership,
+            TeamFoundation.Framework.Common.MembershipQuery queryMembership,
             ReadIdentityOptions readOptions)
         {
             return new[] { NullIdentities };
@@ -250,7 +250,7 @@ namespace Microsoft.Qwiq.Identity.Mocks
         public TeamFoundation.Framework.Client.TeamFoundationIdentity[][] ReadIdentities(
             IdentitySearchFactor searchFactor,
             string[] searchFactorValues,
-            MembershipQuery queryMembership,
+            TeamFoundation.Framework.Common.MembershipQuery queryMembership,
             ReadIdentityOptions readOptions,
             IEnumerable<string> propertyNameFilters,
             IdentityPropertyScope propertyScope)
@@ -261,7 +261,7 @@ namespace Microsoft.Qwiq.Identity.Mocks
         public TeamFoundation.Framework.Client.TeamFoundationIdentity ReadIdentity(
             IdentitySearchFactor searchFactor,
             string searchFactorValue,
-            MembershipQuery queryMembership,
+            TeamFoundation.Framework.Common.MembershipQuery queryMembership,
             ReadIdentityOptions readOptions)
         {
             throw new NotSupportedException();
@@ -270,7 +270,7 @@ namespace Microsoft.Qwiq.Identity.Mocks
         public TeamFoundation.Framework.Client.TeamFoundationIdentity ReadIdentity(
             IdentitySearchFactor searchFactor,
             string searchFactorValue,
-            MembershipQuery queryMembership,
+            TeamFoundation.Framework.Common.MembershipQuery queryMembership,
             ReadIdentityOptions readOptions,
             IEnumerable<string> propertyNameFilters,
             IdentityPropertyScope propertyScope)

--- a/test/Qwiq.Integration.Tests/Identity/Soap/IdentityManagementServiceTests.cs
+++ b/test/Qwiq.Integration.Tests/Identity/Soap/IdentityManagementServiceTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Should;
+
+namespace Microsoft.Qwiq.Identity.Soap
+{
+    [TestClass]
+    public class Given_an_Account_with_Group_Membership : SoapIdentityManagementServiceContextSpecification
+    {
+        private string _input;
+        private ITeamFoundationIdentity _result;
+
+        public override void Given()
+        {
+            base.Given();
+
+            _input = "rimuri@microsoft.com";
+        }
+
+        public override void When()
+        {
+            _result = Instance.ReadIdentity(IdentitySearchFactor.AccountName, _input, MembershipQuery.Expanded);
+        }
+
+        [TestMethod]
+        [TestCategory("localOnly")]
+        [TestCategory("SOAP")]
+        public void Identity_Contains_MemberOf()
+        {
+            _result.MemberOf.Any().ShouldBeTrue();
+        }
+    }
+}

--- a/test/Qwiq.Integration.Tests/Qwiq.IntegrationTests.csproj
+++ b/test/Qwiq.Integration.Tests/Qwiq.IntegrationTests.csproj
@@ -191,6 +191,7 @@
     </Compile>
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Identity\IdentityMapperTests.cs" />
+    <Compile Include="Identity\Soap\IdentityManagementServiceTests.cs" />
     <Compile Include="Identity\Soap\SoapIdentityManagementServiceContextSpecification.cs" />
     <Compile Include="Identity\Soap\SoapIdentityMapperContextSpecification.cs" />
     <Compile Include="IntegrationSettings.cs" />

--- a/test/Qwiq.Mocks/MockIdentityManagementService.cs
+++ b/test/Qwiq.Mocks/MockIdentityManagementService.cs
@@ -124,6 +124,21 @@ namespace Microsoft.Qwiq.Mocks
         /// </returns>
         public IEnumerable<ITeamFoundationIdentity> ReadIdentities(IEnumerable<IIdentityDescriptor> descriptors)
         {
+            return ReadIdentities(descriptors, MembershipQuery.None);
+        }
+
+        /// <summary>
+        ///     Read identities for given descriptors.
+        /// </summary>
+        /// <param name="descriptors">
+        ///     Collection of <see cref="IIdentityDescriptor" />
+        /// </param>
+        /// <param name="queryMembership"></param>
+        /// <returns>
+        ///     An array of <see cref="ITeamFoundationIdentity" />, corresponding 1 to 1 with input descriptor array.
+        /// </returns>
+        public IEnumerable<ITeamFoundationIdentity> ReadIdentities(IEnumerable<IIdentityDescriptor> descriptors, MembershipQuery queryMembership)
+        {
             foreach (var descriptor in descriptors)
             {
                 var success = _descriptorMappings.TryGetValue(descriptor, out ITeamFoundationIdentity identity);
@@ -137,6 +152,14 @@ namespace Microsoft.Qwiq.Mocks
         public IEnumerable<KeyValuePair<string, IEnumerable<ITeamFoundationIdentity>>> ReadIdentities(
             IdentitySearchFactor searchFactor,
             IEnumerable<string> searchFactorValues)
+        {
+            return ReadIdentities(searchFactor, searchFactorValues, MembershipQuery.None);
+        }
+
+        public IEnumerable<KeyValuePair<string, IEnumerable<ITeamFoundationIdentity>>> ReadIdentities(
+            IdentitySearchFactor searchFactor,
+            IEnumerable<string> searchFactorValues,
+            MembershipQuery queryMembership)
         {
             Trace.TraceInformation($"Searching for {searchFactor}: {string.Join(", ", searchFactorValues)}");
 
@@ -163,10 +186,17 @@ namespace Microsoft.Qwiq.Mocks
             }
         }
 
-        /// <inheritdoc />
-        public ITeamFoundationIdentity ReadIdentity(IdentitySearchFactor searchFactor, string searchFactorValue)
+        public ITeamFoundationIdentity ReadIdentity(
+            IdentitySearchFactor searchFactor,
+            string searchFactorValue)
         {
-            return ReadIdentities(searchFactor, new[] { searchFactorValue }).First().Value.SingleOrDefault();
+            return ReadIdentity(searchFactor, searchFactorValue, MembershipQuery.None);
+        }
+
+        /// <inheritdoc />
+        public ITeamFoundationIdentity ReadIdentity(IdentitySearchFactor searchFactor, string searchFactorValue, MembershipQuery queryMembership)
+        {
+            return ReadIdentities(searchFactor, new[] { searchFactorValue }, queryMembership).First().Value.SingleOrDefault();
         }
 
         private IEnumerable<ITeamFoundationIdentity> Locate(Func<ITeamFoundationIdentity, bool> predicate)


### PR DESCRIPTION
Add new methods to allow callers to control how an `ITeamFoundationIdentity` properties for `Members` and `MemberOf` are populated.

Existing methods call into the new methods passing `MembershipQuery.None`, which was previously hard-coded

Resolves #148 