### PR TITLE
Catch `DeniedOrNotExistException` when accessing field during map

### DIFF
--- a/src/Qwiq.Mapper/Attributes/AttributeMapperStrategy.cs
+++ b/src/Qwiq.Mapper/Attributes/AttributeMapperStrategy.cs
@@ -133,7 +133,18 @@ namespace Microsoft.Qwiq.Mapper.Attributes
                 var fieldName = a.FieldName;
                 var convert = a.RequireConversion;
                 var nullSub = a.NullSubstitute;
-                var fieldValue = sourceWorkItem[fieldName];
+                object fieldValue;
+                try
+                {
+                    fieldValue = sourceWorkItem[fieldName];
+                }
+                catch (DeniedOrNotExistException e)
+                {
+                    var tm = new TypePair(sourceWorkItem, targetWorkItemType);
+                    var pm = new PropertyMap(property, fieldName);
+                    var message = $"Unable to get field value on {sourceWorkItem.Id}.";
+                    throw new AttributeMapException(message, e, tm, pm);
+                }
 
                 AssignFieldValue(targetWorkItemType, sourceWorkItem, targetWorkItem, property, fieldName, convert, nullSub, fieldValue);
             }


### PR DESCRIPTION
While mapping a `Microsoft.Qwiq.DeniedOrNotExistException` may be encountered while attempting to read a value from `IWorkItem` of a field that does not exist. This change captures the exception and throws an `AttributeMapException` indicating the work item ID, WIT field, and destination property that triggered the error.

Resolves #150