### PR TITLE
clean up attribute mapper

### DIFF
--- a/src/Qwiq.Mapper/AnnotatedPropertyValidator.cs
+++ b/src/Qwiq.Mapper/AnnotatedPropertyValidator.cs
@@ -1,0 +1,72 @@
+using JetBrains.Annotations;
+using Microsoft.Qwiq.Mapper.Attributes;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Microsoft.Qwiq.Mapper
+{
+    public class AnnotatedPropertyValidator : IAnnotatedPropertyValidator
+    {
+        private static readonly Type AttributeType = typeof(FieldDefinitionAttribute);
+        private static readonly ConcurrentDictionary<Tuple<string, RuntimeTypeHandle>, Dictionary<PropertyInfo, FieldDefinitionAttribute>> PropertiesThatExistOnWorkItem = new ConcurrentDictionary<Tuple<string, RuntimeTypeHandle>, Dictionary<PropertyInfo, FieldDefinitionAttribute>>();
+        private static readonly ConcurrentDictionary<PropertyInfo, FieldDefinitionAttribute> PropertyInfoFields = new ConcurrentDictionary<PropertyInfo, FieldDefinitionAttribute>();
+        private readonly IPropertyInspector _inspector;
+        private Func<IWorkItem, PropertyInfo, bool> _propertyInfoValidator;
+
+        public AnnotatedPropertyValidator([NotNull] IPropertyInspector inspector)
+        {
+            _inspector = inspector ?? throw new ArgumentNullException(nameof(inspector));
+            PropertyInfoValidator = (item, info) => !string.IsNullOrWhiteSpace(GetFieldDefinition(info)?.FieldName);
+        }
+
+        public Func<IWorkItem, PropertyInfo, bool> PropertyInfoValidator
+        {
+            get => _propertyInfoValidator;
+            set
+            {
+                _propertyInfoValidator = value;
+                PropertiesThatExistOnWorkItem.Clear();
+            }
+        }
+
+        public FieldDefinitionAttribute GetFieldDefinition(PropertyInfo property)
+        {
+            if (property == null) throw new ArgumentNullException(nameof(property));
+            return PropertyInfoFields.GetOrAdd(
+                property,
+                info => _inspector.GetAttribute<FieldDefinitionAttribute>(property));
+        }
+
+        public IEnumerable<KeyValuePair<PropertyInfo, FieldDefinitionAttribute>> GetValidAnnotatedProperties(IWorkItem workItem, Type targetType)
+        {
+            var workItemTypeName = workItem.WorkItemType;
+            var key = new Tuple<string, RuntimeTypeHandle>(workItemTypeName, targetType.TypeHandle);
+
+            Dictionary<PropertyInfo, FieldDefinitionAttribute> ValueFactory(Tuple<string, RuntimeTypeHandle> tuple)
+            {
+                var props = _inspector.GetAnnotatedProperties(targetType, AttributeType);
+                var retval = new Dictionary<PropertyInfo, FieldDefinitionAttribute>();
+                foreach (var prop in props)
+                {
+                    if (prop == null) continue;
+                    var attribute = GetFieldDefinition(prop);
+                    if (attribute == null) continue;
+
+                    if (PropertyInfoValidator(workItem, prop))
+                    {
+                        retval.Add(prop, attribute);
+                    }
+                }
+
+                return retval;
+            }
+
+            return PropertiesThatExistOnWorkItem.GetOrAdd(
+                key,
+                ValueFactory
+            );
+        }
+    }
+}

--- a/src/Qwiq.Mapper/Attributes/AttributeMapperStrategy.cs
+++ b/src/Qwiq.Mapper/Attributes/AttributeMapperStrategy.cs
@@ -15,12 +15,37 @@ namespace Microsoft.Qwiq.Mapper.Attributes
         [NotNull] private readonly IPropertyInspector _inspector;
         [NotNull] private readonly ITypeParser _typeParser;
 
+        /// <summary>
+        /// Creates a default instance of <see cref="AttributeMapperStrategy"/> with <see cref="PropertyReflector"/>.
+        /// </summary>
+        public AttributeMapperStrategy()
+            : this(new PropertyReflector())
+        {
+        }
 
+        /// <summary>
+        /// Creates a new instance of <see cref="AttributeMapperStrategy"/> with the specified <paramref name="propertyReflector"/>.
+        /// </summary>
+        /// <param name="propertyReflector">An instance of <see cref="IPropertyReflector"/>.</param>
+        public AttributeMapperStrategy([NotNull] IPropertyReflector propertyReflector)
+            : this(new PropertyInspector(propertyReflector))
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="AttributeMapperStrategy"/> with the specified <paramref name="inspector"/> and a default instance of <see cref="ITypeParser"/>.
+        /// </summary>
+        /// <param name="inspector">An instance of <see cref="IPropertyInspector"/>.</param>
         public AttributeMapperStrategy([NotNull] IPropertyInspector inspector)
             : this(inspector, TypeParser.Default)
         {
         }
 
+        /// <summary>
+        /// Creates a new instance of <see cref="AttributeMapperStrategy"/> with the specified <paramref name="inspector"/> and <paramref name="typeParser"/>.
+        /// </summary>
+        /// <param name="inspector">An instance of <see cref="IPropertyInspector"/>.</param>
+        /// <param name="typeParser">An instance of <see cref="ITypeParser"/>.</param>
         public AttributeMapperStrategy([NotNull] IPropertyInspector inspector, [NotNull] ITypeParser typeParser)
         {
             _typeParser = typeParser ?? throw new ArgumentNullException(nameof(typeParser));

--- a/src/Qwiq.Mapper/Attributes/AttributeMapperStrategy.cs
+++ b/src/Qwiq.Mapper/Attributes/AttributeMapperStrategy.cs
@@ -3,7 +3,6 @@ using JetBrains.Annotations;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 

--- a/src/Qwiq.Mapper/Attributes/AttributeMapperStrategy.cs
+++ b/src/Qwiq.Mapper/Attributes/AttributeMapperStrategy.cs
@@ -133,21 +133,27 @@ namespace Microsoft.Qwiq.Mapper.Attributes
                 var fieldName = a.FieldName;
                 var convert = a.RequireConversion;
                 var nullSub = a.NullSubstitute;
-                object fieldValue;
-                try
-                {
-                    fieldValue = sourceWorkItem[fieldName];
-                }
-                catch (DeniedOrNotExistException e)
-                {
-                    var tm = new TypePair(sourceWorkItem, targetWorkItemType);
-                    var pm = new PropertyMap(property, fieldName);
-                    var message = $"Unable to get field value on {sourceWorkItem.Id}.";
-                    throw new AttributeMapException(message, e, tm, pm);
-                }
+                var fieldValue = GetFieldValue(targetWorkItemType, sourceWorkItem, fieldName, property);
 
                 AssignFieldValue(targetWorkItemType, sourceWorkItem, targetWorkItem, property, fieldName, convert, nullSub, fieldValue);
             }
+        }
+
+        protected internal virtual object GetFieldValue(Type targetWorkItemType, IWorkItem sourceWorkItem, string fieldName, PropertyInfo property)
+        {
+            object fieldValue;
+            try
+            {
+                fieldValue = sourceWorkItem[fieldName];
+            }
+            catch (DeniedOrNotExistException e)
+            {
+                var tm = new TypePair(sourceWorkItem, targetWorkItemType);
+                var pm = new PropertyMap(property, fieldName);
+                var message = $"Unable to get field value on {sourceWorkItem.Id}.";
+                throw new AttributeMapException(message, e, tm, pm);
+            }
+            return fieldValue;
         }
 
         private static IEnumerable<PropertyInfo> PropertiesOnWorkItemCache(IPropertyInspector inspector, IWorkItem workItem, Type targetType, Type attributeType)

--- a/src/Qwiq.Mapper/Attributes/AttributeMapperStrategy.cs
+++ b/src/Qwiq.Mapper/Attributes/AttributeMapperStrategy.cs
@@ -121,9 +121,8 @@ namespace Microsoft.Qwiq.Mapper.Attributes
         {
             var properties = PropertiesOnWorkItemCache(
                 _inspector,
-                sourceWorkItem,
-                targetWorkItemType,
-                typeof(FieldDefinitionAttribute));
+                sourceWorkItem.WorkItemType,
+                targetWorkItemType);
 
             foreach (var property in properties)
             {
@@ -156,11 +155,9 @@ namespace Microsoft.Qwiq.Mapper.Attributes
             return fieldValue;
         }
 
-        private static IEnumerable<PropertyInfo> PropertiesOnWorkItemCache(IPropertyInspector inspector, IWorkItem workItem, Type targetType, Type attributeType)
+        private static IEnumerable<PropertyInfo> PropertiesOnWorkItemCache(IPropertyInspector inspector, string workItemType, Type targetType)
         {
             // Composite key: work item type and target type
-
-            var workItemType = workItem.WorkItemType;
             var key = new Tuple<string, RuntimeTypeHandle>(workItemType, targetType.TypeHandle);
 
             return PropertiesThatExistOnWorkItem.GetOrAdd(

--- a/src/Qwiq.Mapper/Attributes/NoExceptionAttributeMapperStrategy.cs
+++ b/src/Qwiq.Mapper/Attributes/NoExceptionAttributeMapperStrategy.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using JetBrains.Annotations;
+using System;
 using System.Diagnostics;
 using System.Reflection;
-using JetBrains.Annotations;
 
 namespace Microsoft.Qwiq.Mapper.Attributes
 {
@@ -12,9 +12,8 @@ namespace Microsoft.Qwiq.Mapper.Attributes
         }
 
         public NoExceptionAttributeMapperStrategy([NotNull] IPropertyInspector inspector, [NotNull] ITypeParser typeParser)
-            :base(inspector, typeParser)
+            : base(inspector, typeParser)
         {
-
         }
 
         protected internal override void AssignFieldValue(Type targetWorkItemType, IWorkItem sourceWorkItem, object targetWorkItem, PropertyInfo property, string fieldName, bool convert, object nullSub, object fieldValue)
@@ -37,7 +36,9 @@ namespace Microsoft.Qwiq.Mapper.Attributes
                         targetWorkItemType.Name,
                         $"{property.Name} ({property.PropertyType.FullName})");
                 }
+#pragma warning disable RECS0022 // A catch clause that catches System.Exception and has an empty body
                 catch (Exception)
+#pragma warning restore RECS0022 // A catch clause that catches System.Exception and has an empty body
                 {
                     // Best effort
                 }
@@ -54,11 +55,58 @@ namespace Microsoft.Qwiq.Mapper.Attributes
                         $"{property.Name} ({property.PropertyType.FullName})",
                         e.Message);
                 }
+#pragma warning disable RECS0022 // A catch clause that catches System.Exception and has an empty body
                 catch (Exception)
+#pragma warning restore RECS0022 // A catch clause that catches System.Exception and has an empty body
                 {
                     // Best effort
                 }
             }
+        }
+
+        protected internal override object GetFieldValue(Type targetWorkItemType, IWorkItem sourceWorkItem, string fieldName, PropertyInfo property)
+        {
+            try
+            {
+                return base.GetFieldValue(targetWorkItemType, sourceWorkItem, fieldName, property);
+            }
+            catch (DeniedOrNotExistException e)
+            {
+                // This is most likely caused by the field not being on the WIT
+                // Frequently encountered when using a single entity to map different WITs with different sets of fields
+
+                try
+                {
+                    Trace.TraceWarning(e.Message);
+                }
+#pragma warning disable RECS0022 // A catch clause that catches System.Exception and has an empty body
+                catch (Exception)
+#pragma warning restore RECS0022 // A catch clause that catches System.Exception and has an empty body
+                {
+                    // Best effort
+                }
+            }
+            catch (Exception e)
+            {
+                try
+                {
+                    Trace.TraceWarning(
+                        "Could not map field '{0}' from type '{1}' to type '{2}.{3}'. {4}",
+                        fieldName,
+                        sourceWorkItem.WorkItemType,
+                        targetWorkItemType.Name,
+                        $"{property.Name} ({property.PropertyType.FullName})",
+                        e.Message);
+                }
+#pragma warning disable RECS0022 // A catch clause that catches System.Exception and has an empty body
+                catch (Exception)
+#pragma warning restore RECS0022 // A catch clause that catches System.Exception and has an empty body
+                {
+                    // Best effort
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/src/Qwiq.Mapper/Attributes/NoExceptionAttributeMapperStrategy.cs
+++ b/src/Qwiq.Mapper/Attributes/NoExceptionAttributeMapperStrategy.cs
@@ -7,13 +7,51 @@ namespace Microsoft.Qwiq.Mapper.Attributes
 {
     public class NoExceptionAttributeMapperStrategy : AttributeMapperStrategy
     {
-        public NoExceptionAttributeMapperStrategy([NotNull] IPropertyInspector inspector) : base(inspector)
+        /// <summary>
+        /// Creates a default instance of <see cref="NoExceptionAttributeMapperStrategy"/> with <see cref="PropertyReflector"/>.
+        /// </summary>
+        public NoExceptionAttributeMapperStrategy()
+            : base()
         {
         }
 
+        /// <summary>
+        /// Creates a new instance of <see cref="NoExceptionAttributeMapperStrategy"/> with the specified <paramref name="propertyReflector"/>.
+        /// </summary>
+        /// <param name="propertyReflector">An instance of <see cref="IPropertyReflector"/>.</param>
+        public NoExceptionAttributeMapperStrategy([NotNull] IPropertyReflector propertyReflector)
+            : base(propertyReflector)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="NoExceptionAttributeMapperStrategy"/> with the specified <paramref name="inspector"/> and a default instance of <see cref="ITypeParser"/>.
+        /// </summary>
+        /// <param name="inspector">An instance of <see cref="IPropertyInspector"/>.</param>
+        public NoExceptionAttributeMapperStrategy([NotNull] IPropertyInspector inspector)
+            : base(inspector)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="NoExceptionAttributeMapperStrategy"/> with a <see cref="AnnotatedPropertyValidator"/> using the specified <paramref name="inspector"/> and <paramref name="typeParser"/>.
+        /// </summary>
+        /// <param name="inspector">An instance of <see cref="IPropertyInspector"/>.</param>
+        /// <param name="typeParser">An instance of <see cref="ITypeParser"/>.</param>
         public NoExceptionAttributeMapperStrategy([NotNull] IPropertyInspector inspector, [NotNull] ITypeParser typeParser)
             : base(inspector, typeParser)
         {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="NoExceptionAttributeMapperStrategy"/> with the specified <paramref name="annotatedPropertyValidator"/> and <paramref name="typeParser"/>.
+        /// </summary>
+        /// <param name="annotatedPropertyValidator">An instance of <see cref="IAnnotatedPropertyValidator"/>.</param>
+        /// <param name="typeParser">An instance of <see cref="ITypeParser"/>.</param>
+        public NoExceptionAttributeMapperStrategy([NotNull] IAnnotatedPropertyValidator annotatedPropertyValidator, [NotNull] ITypeParser typeParser)
+            : base(annotatedPropertyValidator, typeParser)
+        {
+
         }
 
         protected internal override void AssignFieldValue(Type targetWorkItemType, IWorkItem sourceWorkItem, object targetWorkItem, PropertyInfo property, string fieldName, bool convert, object nullSub, object fieldValue)

--- a/src/Qwiq.Mapper/Attributes/PropertyInspector.cs
+++ b/src/Qwiq.Mapper/Attributes/PropertyInspector.cs
@@ -1,3 +1,4 @@
+using JetBrains.Annotations;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -8,17 +9,17 @@ namespace Microsoft.Qwiq.Mapper.Attributes
 {
     public class PropertyInspector : IPropertyInspector
     {
-        private readonly IPropertyReflector _reflector;
         private static readonly ConcurrentDictionary<RuntimeTypeHandle, ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyInfo>>> AnnotatedProperties = new ConcurrentDictionary<RuntimeTypeHandle, ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyInfo>>>();
+        private readonly IPropertyReflector _reflector;
 
-        public PropertyInspector(IPropertyReflector reflector)
+        public PropertyInspector([NotNull] IPropertyReflector reflector)
         {
-            _reflector = reflector;
+            _reflector = reflector ?? throw new ArgumentNullException(nameof(reflector));
         }
 
         public IEnumerable<PropertyInfo> GetAnnotatedProperties(Type workItemType, Type attributeType)
         {
-           return AnnotatedPropertiesCache(_reflector, workItemType, attributeType);
+            return AnnotatedPropertiesCache(_reflector, workItemType, attributeType);
         }
 
         public T GetAttribute<T>(PropertyInfo property) where T : Attribute
@@ -63,4 +64,3 @@ namespace Microsoft.Qwiq.Mapper.Attributes
         }
     }
 }
-

--- a/src/Qwiq.Mapper/IAnnotatedPropertyValidator.cs
+++ b/src/Qwiq.Mapper/IAnnotatedPropertyValidator.cs
@@ -1,0 +1,36 @@
+using JetBrains.Annotations;
+using Microsoft.Qwiq.Mapper.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Microsoft.Qwiq.Mapper
+{
+    /// <summary>
+    /// Validates <see cref="FieldDefinitionAttribute"/> annotated properties
+    /// </summary>
+    public interface IAnnotatedPropertyValidator
+    {
+        /// <summary>
+        /// Inspects a <see cref="PropertyInfo"/> and <see cref="IWorkItem"/> and returns true if the <see cref="PropertyInfo"/> is valid; otherwise, false.
+        /// </summary>
+        Func<IWorkItem, PropertyInfo, bool> PropertyInfoValidator { get; set; }
+
+        /// <summary>
+        /// Gets an instance of <see cref="FieldDefinitionAttribute"/> for a given <paramref name="property"/>.
+        /// </summary>
+        /// <param name="property">An instance of <see cref="PropertyInfo"/> decorated with <see cref="FieldDefinitionAttribute"/>.</param>
+        /// <returns>If the <paramref name="property"/> is decorated with <see cref="FieldDefinitionAttribute"/> then the attribute; otherwise, null.</returns>
+        [CanBeNull]
+        FieldDefinitionAttribute GetFieldDefinition([NotNull] PropertyInfo property);
+
+        /// <summary>
+        /// Gets and validates annotated properties of <paramref name="targetType"/> against <paramref name="workItem"/>.
+        /// </summary>
+        /// <param name="workItem">An instance of <see cref="IWorkItem"/>.</param>
+        /// <param name="targetType">The type being mapped.</param>
+        /// <returns>A collection of <see cref="PropertyInfo"/> dedocated with <see cref="FieldDefinitionAttribute"/> that are valid.</returns>
+        [NotNull]
+        IEnumerable<KeyValuePair<PropertyInfo, FieldDefinitionAttribute>> GetValidAnnotatedProperties([NotNull] IWorkItem workItem, [NotNull] Type targetType);
+    }
+}

--- a/src/Qwiq.Mapper/Qwiq.Mapper.csproj
+++ b/src/Qwiq.Mapper/Qwiq.Mapper.csproj
@@ -28,7 +28,9 @@
     <Compile Include="..\AssemblyInfo.Common.cs">
       <Link>Properties\AssemblyInfo.Common.cs</Link>
     </Compile>
+    <Compile Include="AnnotatedPropertyValidator.cs" />
     <Compile Include="Attributes\AttributeMapperStrategy.cs" />
+    <Compile Include="IAnnotatedPropertyValidator.cs" />
     <Compile Include="Attributes\NoExceptionAttributeMapperStrategy.cs" />
     <Compile Include="Attributes\FieldDefinitionAttribute.cs" />
     <Compile Include="Attributes\IPropertyInspector.cs" />

--- a/src/Qwiq.Mapper/WorkItemMapper.cs
+++ b/src/Qwiq.Mapper/WorkItemMapper.cs
@@ -16,6 +16,16 @@ namespace Microsoft.Qwiq.Mapper
         private delegate IIdentifiable<int?> ObjectActivator();
         private static readonly ConcurrentDictionary<RuntimeTypeHandle, ObjectActivator> OptimizedCtorExpression = new ConcurrentDictionary<RuntimeTypeHandle, ObjectActivator>();
 
+        public WorkItemMapper([NotNull] params IWorkItemMapperStrategy[] mapperStrategies)
+        {
+            Contract.Requires(mapperStrategies != null);
+
+            if (mapperStrategies == null) throw new ArgumentNullException(nameof(mapperStrategies));
+            if (mapperStrategies.Length == 0) throw new ArgumentException("Value cannot be an empty collection.", nameof(mapperStrategies));
+
+            MapperStrategies = mapperStrategies;
+        }
+
         public WorkItemMapper([NotNull] IEnumerable<IWorkItemMapperStrategy> mapperStrategies)
         {
             Contract.Requires(mapperStrategies != null);


### PR DESCRIPTION
Proposed changes
 - **Bug fix: catch `DeniedOrNotExistException` when fetching property on work item**. This is now extended to the `NoExceptionAttributeMapperStrategy`.
 - **Separation of concerns**. `AttributeMapperStrategy` had three concerns: the reading from and writing to fields and properties, obtaining a list of properties to read/write, validating that list. This is now separated into a new class: `AnnotatedPropertyValidator`
 - **`IAnnotatedPropertyValidator` is accepted by `AttributeMapperStrategy`**.  Additional `.ctor` created to prevent breaking changes, but an instance of `IAnnotatedPropertyValidator` is accepted by `NoExceptionAttributeMapperStrategy` and `AttributeMapperStrategy` to perform field/property validation.