### PR TITLE
Update REST default fields config

### DIFF
--- a/src/Qwiq.Core.Rest/WorkItemStoreConfiguration.cs
+++ b/src/Qwiq.Core.Rest/WorkItemStoreConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 namespace Microsoft.Qwiq.Client.Rest
 {
@@ -17,7 +18,13 @@ namespace Microsoft.Qwiq.Client.Rest
                 CoreFieldRefNames.WorkItemType
             };
 
-        private IEnumerable<string> _defaultFields;
+        private static readonly string[] MandatoryFields =
+        {
+            CoreFieldRefNames.TeamProject,
+            CoreFieldRefNames.WorkItemType,
+        };
+
+        private HashSet<string> _defaultFields;
 
         private WorkItemExpand _workItemExpand;
 
@@ -45,7 +52,16 @@ namespace Microsoft.Qwiq.Client.Rest
                                        $"The {nameof(DefaultFields)} parameter can not be used with the {nameof(WorkItemExpand)} parameter. Setting {nameof(WorkItemExpand)} to {WorkItemExpand.None}.");
                     _workItemExpand = WorkItemExpand.None;
                 }
-                _defaultFields = value;
+                if (value == null || !value.Any()) _defaultFields.Clear();
+                else
+                {
+                    var fs = new HashSet<string>(value, Comparer.OrdinalIgnoreCase);
+                    foreach (var f in MandatoryFields)
+                    {
+                        fs.Add(f);
+                    }
+                    _defaultFields = fs;
+                }
             }
         }
 
@@ -71,7 +87,7 @@ namespace Microsoft.Qwiq.Client.Rest
                 }
                 else
                 {
-                    _defaultFields = DefaultFieldValue;
+                    _defaultFields = new HashSet<string>(DefaultFieldValue, Comparer.OrdinalIgnoreCase);
                 }
             }
         }

--- a/test/Qwiq.Integration.Tests/Mapper/AttributeMapperTests.cs
+++ b/test/Qwiq.Integration.Tests/Mapper/AttributeMapperTests.cs
@@ -22,8 +22,6 @@ namespace Microsoft.Qwiq.Mapper
         {
             WorkItemStore.Configuration.DefaultFields = new[]
             {
-                //CoreFieldRefNames.TeamProject,
-                //CoreFieldRefNames.WorkItemType,
                 CoreFieldRefNames.Id,
                 CoreFieldRefNames.State
             };
@@ -38,7 +36,6 @@ namespace Microsoft.Qwiq.Mapper
         [TestMethod]
         [TestCategory("localOnly")]
         [TestCategory("REST")]
-        [ExpectedException(typeof(InvalidOperationException), "The fields '" + CoreFieldRefNames.TeamProject + "' and '" + CoreFieldRefNames.WorkItemType + "' are required to load the Type property.")]
         public new void The_work_items_are_mapped_to_their_model()
         {
             Bugs.ToList().Count.ShouldEqual(1);
@@ -69,7 +66,6 @@ namespace Microsoft.Qwiq.Mapper
             WorkItemStore.Configuration.DefaultFields = new[]
             {
                 CoreFieldRefNames.TeamProject,
-                //CoreFieldRefNames.WorkItemType,
                 CoreFieldRefNames.Id,
                 CoreFieldRefNames.State
             };
@@ -83,7 +79,6 @@ namespace Microsoft.Qwiq.Mapper
         [TestMethod]
         [TestCategory("localOnly")]
         [TestCategory("REST")]
-        [ExpectedException(typeof(InvalidOperationException), "The fields '" + CoreFieldRefNames.TeamProject + "' and '" + CoreFieldRefNames.WorkItemType + "' are required to load the Type property.")]
         public new void The_work_items_are_mapped_to_their_model()
         {
             Bugs.ToList().Count.ShouldEqual(1);


### PR DESCRIPTION
When default fields are specified, ensure the mandatory fields for TeamProject and WorkItemType are always included. If they are omitted, they are automatically added.

Resolves #172