### PR TITLE
Fix: The REST model contains duplicate field definitions

### DIFF
--- a/src/Qwiq.Core/ReadOnlyCollectionWithId.cs
+++ b/src/Qwiq.Core/ReadOnlyCollectionWithId.cs
@@ -1,6 +1,7 @@
 using JetBrains.Annotations;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 
 namespace Microsoft.Qwiq
@@ -93,13 +94,20 @@ namespace Microsoft.Qwiq
 
         protected void AddById(TId id, int index)
         {
-            try
+            var exists = _mapById.ContainsKey(id);
+
+            Debug.Assert(!exists, $"An item with the ID {id} already exists.");
+
+            if (!exists)
             {
-                _mapById.Add(id, index);
-            }
-            catch (ArgumentException e)
-            {
-                throw new ArgumentException($"An item with the ID {id} already exists.", e);
+                try
+                {
+                    _mapById.Add(id, index);
+                }
+                catch (ArgumentException e)
+                {
+                    throw new ArgumentException($"An item with the ID {id} already exists.", e);
+                }
             }
         }
     }

--- a/src/Qwiq.Core/ReadOnlyObjectWithNameCollection.cs
+++ b/src/Qwiq.Core/ReadOnlyObjectWithNameCollection.cs
@@ -184,14 +184,24 @@ namespace Microsoft.Qwiq
 
         protected void AddByName(string name, int index)
         {
-            try
+
+            var exists = _mapByName.ContainsKey(name);
+
+            Debug.Assert(!exists, $"An item with the name {name} already exists.");
+
+            if (!exists)
             {
-                _mapByName.Add(name, index);
+                try
+                {
+                    _mapByName.Add(name, index);
+                }
+                catch (ArgumentException e)
+                {
+                    throw new ArgumentException($"An item with the name {name} already exists.", e);
+                }
             }
-            catch (ArgumentException e)
-            {
-                throw new ArgumentException($"An item with the name {name} already exists.", e);
-            }
+
+        
         }
 
         protected void Ensure()


### PR DESCRIPTION
The REST model contains duplicates for all field definitions in a WIT, despite the API returning the correct result. The restriction imposed for correctness is relaxed and changed into an Assert, so this condition can be caught in Debug builds. Since Release builds are distributed to customers, the mapping will not be added and future invocations will refer to the existing element.

That is, if IterationPath is contained in ordinal positions 0, 48 the addition of the field at ordinal 48 will not be performed. Any future reference to IterationPath will refer to the field received at position 0.