### PR TITLE
Correct duplicate field definitions rest

### DIFF
--- a/src/Qwiq.Core.Rest/FieldDefinitionCollection.cs
+++ b/src/Qwiq.Core.Rest/FieldDefinitionCollection.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Qwiq.Client.Rest
         }
 
         private FieldDefinitionCollection(List<IFieldDefinition> fieldDefinitions)
-            : base(fieldDefinitions)
+            : base(fieldDefinitions.Distinct().ToList())
         {
         }
     }

--- a/src/Qwiq.Core/ReadOnlyCollectionWithId.cs
+++ b/src/Qwiq.Core/ReadOnlyCollectionWithId.cs
@@ -1,7 +1,6 @@
 using JetBrains.Annotations;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.Contracts;
 
 namespace Microsoft.Qwiq
@@ -94,20 +93,13 @@ namespace Microsoft.Qwiq
 
         protected void AddById(TId id, int index)
         {
-            var exists = _mapById.ContainsKey(id);
-
-            Debug.Assert(!exists, $"An item with the ID {id} already exists.");
-
-            if (!exists)
+            try
             {
-                try
-                {
-                    _mapById.Add(id, index);
-                }
-                catch (ArgumentException e)
-                {
-                    throw new ArgumentException($"An item with the ID {id} already exists.", e);
-                }
+                _mapById.Add(id, index);
+            }
+            catch (ArgumentException e)
+            {
+                throw new ArgumentException($"An item with the ID {id} already exists.", e);
             }
         }
     }

--- a/src/Qwiq.Core/ReadOnlyObjectWithNameCollection.cs
+++ b/src/Qwiq.Core/ReadOnlyObjectWithNameCollection.cs
@@ -184,24 +184,14 @@ namespace Microsoft.Qwiq
 
         protected void AddByName(string name, int index)
         {
-
-            var exists = _mapByName.ContainsKey(name);
-
-            Debug.Assert(!exists, $"An item with the name {name} already exists.");
-
-            if (!exists)
+            try
             {
-                try
-                {
-                    _mapByName.Add(name, index);
-                }
-                catch (ArgumentException e)
-                {
-                    throw new ArgumentException($"An item with the name {name} already exists.", e);
-                }
+                _mapByName.Add(name, index);
             }
-
-        
+            catch (ArgumentException e)
+            {
+                throw new ArgumentException($"An item with the name {name} already exists.", e);
+            }
         }
 
         protected void Ensure()


### PR DESCRIPTION
The REST model contains duplicates for all field definitions in a WIT, despite the API returning the correct result. Reverting change made in ef38e4328ec568239b793fc03ff4ad3949dba1de and instead hotfix the `FieldDefinitionCollection` for the REST implementation only. This changes the runtime from 2n to 3n