### PR TITLE
Add "Work Item Type" to list of override Mappings in SimpleFieldMapper

### DIFF
--- a/src/Qwiq.Linq/SimpleFieldMapper.cs
+++ b/src/Qwiq.Linq/SimpleFieldMapper.cs
@@ -20,7 +20,8 @@ namespace Qwiq.Linq
             {"CreatedBy", "Created By"},
             {"CreatedDate", "Created Date"},
             {"IterationPath", "Iteration Path"},
-            {"RevisedDate", "Revised Date"}
+            {"RevisedDate", "Revised Date"},
+            {"WorkItemType", "Work Item Type"}
         };
 
         // REVIEW: Replace with more constrained set of fields

--- a/test/Qwiq.Linq.Tests/QueryBuilderTests.cs
+++ b/test/Qwiq.Linq.Tests/QueryBuilderTests.cs
@@ -697,4 +697,21 @@ namespace Qwiq.Linq
             Actual.ShouldEqual(Expected);
         }
     }
+
+    [TestClass]
+    public class given_a_query_on_WorkItemType : WiqlQueryBuilderContextSpecification
+    {
+        public override void When()
+        {
+            base.When();
+            Expected = "SELECT * FROM WorkItems WHERE (([Work Item Type] = 'Bug'))";
+            Actual = Query.Where(item => item.WorkItemType == "Bug").ToString();
+        }
+
+        [TestMethod]
+        public void the_value_is_written_to_WIQL()
+        {
+            Actual.ShouldEqual(Expected);
+        }
+    }
 }


### PR DESCRIPTION
In the future the `SimpleFieldMapper` should instead consult the WIT for ReferenceNames of fields. Until then, add "WorkItemType" -> "Work Item Type" conversion, so the fields we currently expose of `IWorkItem` work.