### PR TITLE
Automatic update of Newtonsoft.Json to 10.0.3

### DIFF
--- a/src/Qwiq.Core.Rest/Qwiq.Client.Rest.csproj
+++ b/src/Qwiq.Core.Rest/Qwiq.Client.Rest.csproj
@@ -59,8 +59,9 @@
     <Reference Include="Microsoft.VisualStudio.Services.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Services.Client.15.112.1\lib\net45\Microsoft.VisualStudio.Services.WebApi.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Qwiq.Core.Rest/packages.config
+++ b/src/Qwiq.Core.Rest/packages.config
@@ -7,6 +7,6 @@
   <package id="Microsoft.TeamFoundationServer.Client" version="15.112.1" targetFramework="net46" />
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Services.Client" version="15.112.1" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net46" />
   <package id="UtilPack.NuGet.MSBuild" version="2.8.0" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/src/Qwiq.Core.Soap/Qwiq.Client.Soap.csproj
+++ b/src/Qwiq.Core.Soap/Qwiq.Client.Soap.csproj
@@ -145,8 +145,9 @@
     <Reference Include="Microsoft.VisualStudio.Services.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Services.Client.15.112.1\lib\net45\Microsoft.VisualStudio.Services.WebApi.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Qwiq.Core.Soap/packages.config
+++ b/src/Qwiq.Core.Soap/packages.config
@@ -11,7 +11,7 @@
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Services.Client" version="15.112.1" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Services.InteractiveClient" version="15.112.1" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net46" />
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.4.403061554" targetFramework="net46" />
   <package id="UtilPack.NuGet.MSBuild" version="2.8.0" targetFramework="net46" developmentDependency="true" />
   <package id="WindowsAzure.ServiceBus" version="3.3.2" targetFramework="net46" />

--- a/src/Qwiq.Core/Qwiq.Core.csproj
+++ b/src/Qwiq.Core/Qwiq.Core.csproj
@@ -43,8 +43,9 @@
     <Reference Include="Microsoft.VisualStudio.Services.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Services.Client.15.112.1\lib\net45\Microsoft.VisualStudio.Services.WebApi.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Qwiq.Core/packages.config
+++ b/src/Qwiq.Core/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.Net.Compilers" version="2.8.2" targetFramework="net46" developmentDependency="true" />
   <package id="Microsoft.VisualStudio.Services.Client" version="15.112.1" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Services.InteractiveClient" version="15.112.1" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net46" />
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.4.403061554" targetFramework="net46" />
   <package id="UtilPack.NuGet.MSBuild" version="2.8.0" targetFramework="net46" developmentDependency="true" />
   <package id="WindowsAzure.ServiceBus" version="3.3.2" targetFramework="net46" />

--- a/src/Qwiq.Identity.Soap/Qwiq.Identity.Soap.csproj
+++ b/src/Qwiq.Identity.Soap/Qwiq.Identity.Soap.csproj
@@ -145,8 +145,9 @@
     <Reference Include="Microsoft.VisualStudio.Services.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Services.Client.15.112.1\lib\net45\Microsoft.VisualStudio.Services.WebApi.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Qwiq.Identity.Soap/packages.config
+++ b/src/Qwiq.Identity.Soap/packages.config
@@ -11,7 +11,7 @@
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Services.Client" version="15.112.1" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Services.InteractiveClient" version="15.112.1" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net46" />
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.4.403061554" targetFramework="net46" />
   <package id="UtilPack.NuGet.MSBuild" version="2.8.0" targetFramework="net46" developmentDependency="true" />
   <package id="WindowsAzure.ServiceBus" version="3.3.2" targetFramework="net46" />

--- a/src/Qwiq.Identity/Qwiq.Identity.csproj
+++ b/src/Qwiq.Identity/Qwiq.Identity.csproj
@@ -58,8 +58,9 @@
     <Reference Include="Microsoft.VisualStudio.Services.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Services.Client.15.112.1\lib\net45\Microsoft.VisualStudio.Services.WebApi.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/Qwiq.Identity/packages.config
+++ b/src/Qwiq.Identity/packages.config
@@ -4,6 +4,6 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Net.Compilers" version="2.8.2" targetFramework="net46" developmentDependency="true" />
   <package id="Microsoft.VisualStudio.Services.Client" version="15.112.1" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net46" />
   <package id="UtilPack.NuGet.MSBuild" version="2.8.0" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/test/Qwiq.Core.Tests/Qwiq.Core.UnitTests.csproj
+++ b/test/Qwiq.Core.Tests/Qwiq.Core.UnitTests.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="15.112.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Should" Version="1.1.20" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="4.0.4.403061554" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="3.3.2" />

--- a/test/Qwiq.Identity.Tests/Qwiq.Identity.UnitTests.csproj
+++ b/test/Qwiq.Identity.Tests/Qwiq.Identity.UnitTests.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="15.112.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Should" Version="1.1.20" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="4.0.4.403061554" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="3.3.2" />

--- a/test/Qwiq.Integration.Tests/Qwiq.IntegrationTests.csproj
+++ b/test/Qwiq.Integration.Tests/Qwiq.IntegrationTests.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="15.112.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Should" Version="1.1.20" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="4.0.4.403061554" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="3.3.2" />

--- a/test/Qwiq.Mapper.Benchmark.Tests/Qwiq.Mapper.BenchmarkTests.csproj
+++ b/test/Qwiq.Mapper.Benchmark.Tests/Qwiq.Mapper.BenchmarkTests.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Should" Version="1.1.20" />
     <PackageReference Include="System.AppContext" Version="4.3.0" />
     <PackageReference Include="System.Collections" Version="4.3.0" />

--- a/test/Qwiq.Mapper.Tests/Qwiq.Mapper.UnitTests.csproj
+++ b/test/Qwiq.Mapper.Tests/Qwiq.Mapper.UnitTests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="15.112.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Should" Version="1.1.20" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Qwiq.Mocks/Qwiq.Mocks.csproj
+++ b/test/Qwiq.Mocks/Qwiq.Mocks.csproj
@@ -26,8 +26,9 @@
     <Reference Include="Microsoft.VisualStudio.Services.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Services.Client.15.112.1\lib\net45\Microsoft.VisualStudio.Services.WebApi.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/test/Qwiq.Mocks/packages.config
+++ b/test/Qwiq.Mocks/packages.config
@@ -4,6 +4,6 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Net.Compilers" version="2.8.2" targetFramework="net46" developmentDependency="true" />
   <package id="Microsoft.VisualStudio.Services.Client" version="15.112.1" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net46" />
   <package id="UtilPack.NuGet.MSBuild" version="2.8.0" targetFramework="net46" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Newtonsoft.Json` to `10.0.3` from `10.0.2`
`Newtonsoft.Json 10.0.3` was published at `2017-06-18T02:10:29Z`, 1 year and 9 months ago
There is also a higher version, `Newtonsoft.Json 12.0.1` published at `2018-11-27T18:11:37Z`, 4 months ago, but this was not applied as only `Minor` version changes are allowed.

11 project updates:
Updated `test\Qwiq.Core.Tests\Qwiq.Core.UnitTests.csproj` to `Newtonsoft.Json` `10.0.3` from `10.0.2`
Updated `test\Qwiq.Identity.Tests\Qwiq.Identity.UnitTests.csproj` to `Newtonsoft.Json` `10.0.3` from `10.0.2`
Updated `test\Qwiq.Integration.Tests\Qwiq.IntegrationTests.csproj` to `Newtonsoft.Json` `10.0.3` from `10.0.2`
Updated `test\Qwiq.Mapper.Benchmark.Tests\Qwiq.Mapper.BenchmarkTests.csproj` to `Newtonsoft.Json` `10.0.3` from `10.0.2`
Updated `test\Qwiq.Mapper.Tests\Qwiq.Mapper.UnitTests.csproj` to `Newtonsoft.Json` `10.0.3` from `10.0.2`
Updated `src\Qwiq.Core\packages.config` to `Newtonsoft.Json` `10.0.3` from `10.0.2`
Updated `src\Qwiq.Core.Rest\packages.config` to `Newtonsoft.Json` `10.0.3` from `10.0.2`
Updated `src\Qwiq.Core.Soap\packages.config` to `Newtonsoft.Json` `10.0.3` from `10.0.2`
Updated `src\Qwiq.Identity\packages.config` to `Newtonsoft.Json` `10.0.3` from `10.0.2`
Updated `src\Qwiq.Identity.Soap\packages.config` to `Newtonsoft.Json` `10.0.3` from `10.0.2`
Updated `test\Qwiq.Mocks\packages.config` to `Newtonsoft.Json` `10.0.3` from `10.0.2`

[Newtonsoft.Json 10.0.3 on NuGet.org](https://www.nuget.org/packages/Newtonsoft.Json/10.0.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
