### PR TITLE
Automatic update of Microsoft.AspNet.WebApi.Client to 5.2.7

### DIFF
--- a/src/Qwiq.Core.Rest/Qwiq.Client.Rest.csproj
+++ b/src/Qwiq.Core.Rest/Qwiq.Client.Rest.csproj
@@ -66,8 +66,9 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Threading.Tasks.Dataflow, Version=4.5.24.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>

--- a/src/Qwiq.Core.Rest/packages.config
+++ b/src/Qwiq.Core.Rest/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GitVersionTask" version="4.0.0" targetFramework="net46" developmentDependency="true" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net46" />
   <package id="Microsoft.Net.Compilers" version="2.8.2" targetFramework="net46" developmentDependency="true" />
   <package id="Microsoft.TeamFoundation.DistributedTask.Common" version="15.112.1" targetFramework="net46" />
   <package id="Microsoft.TeamFoundationServer.Client" version="15.112.1" targetFramework="net46" />

--- a/src/Qwiq.Core.Soap/Qwiq.Client.Soap.csproj
+++ b/src/Qwiq.Core.Soap/Qwiq.Client.Soap.csproj
@@ -155,8 +155,9 @@
       <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.4.0.4.403061554\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />

--- a/src/Qwiq.Core.Soap/packages.config
+++ b/src/Qwiq.Core.Soap/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GitVersionTask" version="4.0.0" targetFramework="net46" developmentDependency="true" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.9" targetFramework="net46" />
   <package id="Microsoft.Net.Compilers" version="2.8.2" targetFramework="net46" developmentDependency="true" />

--- a/src/Qwiq.Core/Qwiq.Core.csproj
+++ b/src/Qwiq.Core/Qwiq.Core.csproj
@@ -53,8 +53,9 @@
       <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.4.0.4.403061554\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />

--- a/src/Qwiq.Core/packages.config
+++ b/src/Qwiq.Core/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Castle.Core" version="4.0.0" targetFramework="net46" />
   <package id="GitVersionTask" version="4.0.0" targetFramework="net46" developmentDependency="true" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.9" targetFramework="net46" />
   <package id="Microsoft.Net.Compilers" version="2.8.2" targetFramework="net46" developmentDependency="true" />
   <package id="Microsoft.VisualStudio.Services.Client" version="15.112.1" targetFramework="net46" />

--- a/src/Qwiq.Identity.Soap/Qwiq.Identity.Soap.csproj
+++ b/src/Qwiq.Identity.Soap/Qwiq.Identity.Soap.csproj
@@ -155,8 +155,9 @@
       <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.4.0.4.403061554\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />

--- a/src/Qwiq.Identity.Soap/packages.config
+++ b/src/Qwiq.Identity.Soap/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GitVersionTask" version="4.0.0" targetFramework="net46" developmentDependency="true" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.9" targetFramework="net46" />
   <package id="Microsoft.Net.Compilers" version="2.8.2" targetFramework="net46" developmentDependency="true" />

--- a/src/Qwiq.Identity/Qwiq.Identity.csproj
+++ b/src/Qwiq.Identity/Qwiq.Identity.csproj
@@ -64,8 +64,9 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />

--- a/src/Qwiq.Identity/packages.config
+++ b/src/Qwiq.Identity/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GitVersionTask" version="4.0.0" targetFramework="net46" developmentDependency="true" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net46" />
   <package id="Microsoft.Net.Compilers" version="2.8.2" targetFramework="net46" developmentDependency="true" />
   <package id="Microsoft.VisualStudio.Services.Client" version="15.112.1" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net46" />

--- a/test/Qwiq.Core.Tests/Qwiq.Core.UnitTests.csproj
+++ b/test/Qwiq.Core.Tests/Qwiq.Core.UnitTests.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GitVersionTask" Version="4.0.0" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.3" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.3" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.13.9" />
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.8.2" />

--- a/test/Qwiq.Identity.Tests/Qwiq.Identity.UnitTests.csproj
+++ b/test/Qwiq.Identity.Tests/Qwiq.Identity.UnitTests.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GitVersionTask" Version="4.0.0" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.3" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.3" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.13.9" />
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.8.2" />

--- a/test/Qwiq.Integration.Tests/Qwiq.IntegrationTests.csproj
+++ b/test/Qwiq.Integration.Tests/Qwiq.IntegrationTests.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="GitVersionTask" Version="4.0.0" />
     <PackageReference Include="JetBrains.dotMemoryUnit" Version="2.3.20160517.113140" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.3" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.3" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.13.9" />
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.8.2" />

--- a/test/Qwiq.Mapper.Tests/Qwiq.Mapper.UnitTests.csproj
+++ b/test/Qwiq.Mapper.Tests/Qwiq.Mapper.UnitTests.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GitVersionTask" Version="4.0.0" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.3" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.8.2" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="15.112.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />

--- a/test/Qwiq.Mocks/Qwiq.Mocks.csproj
+++ b/test/Qwiq.Mocks/Qwiq.Mocks.csproj
@@ -32,8 +32,9 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/test/Qwiq.Mocks/packages.config
+++ b/test/Qwiq.Mocks/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GitVersionTask" version="4.0.0" targetFramework="net46" developmentDependency="true" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net46" />
   <package id="Microsoft.Net.Compilers" version="2.8.2" targetFramework="net46" developmentDependency="true" />
   <package id="Microsoft.VisualStudio.Services.Client" version="15.112.1" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net46" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.AspNet.WebApi.Client` to `5.2.7` from `5.2.3`
`Microsoft.AspNet.WebApi.Client 5.2.7` was published at `2018-11-29T00:07:22Z`, 4 months ago

10 project updates:
Updated `test\Qwiq.Core.Tests\Qwiq.Core.UnitTests.csproj` to `Microsoft.AspNet.WebApi.Client` `5.2.7` from `5.2.3`
Updated `test\Qwiq.Identity.Tests\Qwiq.Identity.UnitTests.csproj` to `Microsoft.AspNet.WebApi.Client` `5.2.7` from `5.2.3`
Updated `test\Qwiq.Integration.Tests\Qwiq.IntegrationTests.csproj` to `Microsoft.AspNet.WebApi.Client` `5.2.7` from `5.2.3`
Updated `test\Qwiq.Mapper.Tests\Qwiq.Mapper.UnitTests.csproj` to `Microsoft.AspNet.WebApi.Client` `5.2.7` from `5.2.3`
Updated `src\Qwiq.Core\packages.config` to `Microsoft.AspNet.WebApi.Client` `5.2.7` from `5.2.3`
Updated `src\Qwiq.Core.Rest\packages.config` to `Microsoft.AspNet.WebApi.Client` `5.2.7` from `5.2.3`
Updated `src\Qwiq.Core.Soap\packages.config` to `Microsoft.AspNet.WebApi.Client` `5.2.7` from `5.2.3`
Updated `src\Qwiq.Identity\packages.config` to `Microsoft.AspNet.WebApi.Client` `5.2.7` from `5.2.3`
Updated `src\Qwiq.Identity.Soap\packages.config` to `Microsoft.AspNet.WebApi.Client` `5.2.7` from `5.2.3`
Updated `test\Qwiq.Mocks\packages.config` to `Microsoft.AspNet.WebApi.Client` `5.2.7` from `5.2.3`

[Microsoft.AspNet.WebApi.Client 5.2.7 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNet.WebApi.Client/5.2.7)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
